### PR TITLE
base: add ca-certificates

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM google/debian:wheezy
 
-RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential git
+RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential git ca-certificates
 RUN mkdir /nodejs && curl http://nodejs.org/dist/v0.10.28/node-v0.10.28-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
 
 ENV PATH $PATH:/nodejs/bin


### PR DESCRIPTION
This is need by npm to pull over https.
