### PR TITLE
Update to the latest node 0.10

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM google/debian:wheezy
 
 RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential git ca-certificates
-RUN mkdir /nodejs && curl http://nodejs.org/dist/v0.10.33/node-v0.10.33-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
+RUN mkdir /nodejs && curl https://nodejs.org/dist/v0.10.40/node-v0.10.40-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
 
 ENV PATH $PATH:/nodejs/bin


### PR DESCRIPTION
There have been a lot of fixes, and the latest 0.10.40 actually includes a fix for the OpenSSL security vulnerability.