### PR TITLE
Upgraded node.js version to 0.12.7

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM google/debian:wheezy
 
 RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential git ca-certificates
-RUN mkdir /nodejs && curl https://nodejs.org/dist/v0.10.40/node-v0.10.40-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
+RUN mkdir /nodejs && curl https://nodejs.org/dist/v0.12.7/node-v0.12.7-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
 
 ENV PATH $PATH:/nodejs/bin


### PR DESCRIPTION
I went ahead and created this pull request in case you guys are in favor of the issue.  I hadn't noticed many responses to the a similar issue for a different upgrade issue.  In the meantime, on your docker page it says "google/nodejs is a docker base image that bundles the latest version of nodejs and npm installed from nodejs.org" yet it's a bit behind.