### PR TITLE
Adding install_node script to base image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@ nodejs-docker
 
 This repository contains the sources for the following [docker](https://docker.io) base images:
 - [`gcr.io/google_appengine/nodejs`](/base)
+
+For more infomation on using this image in your project, see the [README for the base image](base/README.md).

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,10 +7,17 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl pyth
 
 # Install the latest LTS release of nodejs
 RUN mkdir /nodejs && curl https://nodejs.org/dist/v4.2.2/node-v4.2.2-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
+ENV PATH $PATH:/nodejs/bin
+
+# Install semver, as required by the node version install script.
+RUN npm install https://storage.googleapis.com/gae_node_packages/semver.tar.gz
+
+# Add the node version install script
+ADD install_node /usr/local/bin/install_node
 
 # Set common env vars
-ENV PATH $PATH:/nodejs/bin
 ENV NODE_ENV production
+
 WORKDIR /app
 
 # start

--- a/base/README.md
+++ b/base/README.md
@@ -1,17 +1,44 @@
-# google/nodejs
+# Google Cloud Platform Node.js Docker Image
 
-[`gcr.io/google_appengine/nodejs`](https://cloud.google.com/nodejs) is a [docker](https://docker.io) base image that bundles selected versions of [nodejs](https://nodejs.org) and [npm](https://npmjs.org) installed from [nodejs.org](http://nodejs.org/download/).
+This repository contains the source for the `gcr.io/google_appengine/nodejs` [docker](https://docker.com) image. This image can be used as the base image for running applications on [Google App Engine Managed VMs](https://cloud.google.com/appengine), [Google Container Engine](https://cloud.google.com/container-engine), or any other Docker host.
 
-## Usage
+This image is based on Debian Jessie and includes [nodejs](https://nodejs.org) and [npm](https://npmjs.org) installed from [nodejs.org](http://nodejs.org/download/).
 
-- Create a Dockerfile in your nodejs application directory with the following content:
+## App Engine
+
+To generate a Dockerfile that uses this image as a base, use the [`Cloud SDK`](https://cloud.google.com/sdk/gcloud/reference/preview/app/gen-config):
+
+    gcloud preview app gen-config --custom 
+
+You can then modify the `Dockerfile` and `.dockerignore` as needed for you application.
+
+## Container Engine & other Docker hosts.
+
+For other docker hosts, you'll need to create a `Dockerfile` based on this image that copies your application code and installs dependencies. For example:
 
         FROM gcr.io/google_appengine/nodejs
-        ADD package.json npm-shrinkwrap.json* /app/
+
+        # Copy application code.
+        COPY . /app/
+
+        # Install dependencies.
         RUN npm --unsafe-perm install
-        ADD . /app
-        
-- Run the following command in your application directory:
 
-        docker build -t my/app .
+By default, the `CMD` is set to `npm start`. You can change this by specifying your own [`CMD` or `ENTRYPOINT`](http://docs.docker.com/engine/reference/builder/#cmd).
 
+## Installing a different Node.js version
+
+The image includes the `install_node` script that can be used to install a particular Node.js version. For example:
+
+        FROM gcr.io/google_appengine/nodejs
+
+        # Install node.js 0.12.7
+        RUN install_node v0.12.7
+
+        # Copy application code.
+        COPY . /app/
+
+        # Install dependencies.
+        RUN npm --unsafe-perm install
+
+Node.js is installed with binary packages hosted on a Google-provided mirror.

--- a/base/install_node
+++ b/base/install_node
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+var semver = require('semver');
+var http = require('http');
+var exec = require('child_process').exec;
+
+function request(method, host, path, cb) {
+  var options = {
+    'host': host,
+    'method': method,
+    'path': path
+  };
+
+  var req = http.request(options, function(res) {
+    if (res.statusCode != 200) {
+      return cb(new Error('Returned status code: ' + res.statusCode));
+    }
+
+    var body = '';
+
+    res.on('data', function(d) {
+      body += d;
+    });
+
+    res.on('end', function() {
+      cb(null, body, res);
+    });
+  });
+
+  req.end();
+}
+
+
+function getAvailableVersions(cb) {
+  request(
+    'GET', 'storage.googleapis.com', '/gae_node_packages/node_versions',
+    function(err, body) {
+      if (err) {
+        return cb(err);
+      }
+      return cb(null, body.trim().split('\n').sort().reverse());
+    }
+  );
+}
+
+
+function getSatisfyingVersion(requestedVersion, cb) {
+  getAvailableVersions(function(err, versions) {
+    if (err) {
+      return cb(err);
+    }
+    var satisfied = versions.some(function(version) {
+      if (semver.satisfies(version, requestedVersion)) {
+        cb(null, version);
+        return true;
+      }
+    });
+    if (!satisfied) {
+      return cb(new Error(
+        'No Node.js version satisfying ' + requestedVersion + ' found.'));
+    }
+  });
+}
+
+
+function verifyBinaryExists(version, cb) {
+  request(
+    'HEAD',
+    'storage.googleapis.com',
+    '/gae_node_packages/node-' + version + '-linux-x64.tar.gz',
+    function(err) {
+      if (err) {
+        return cb(new Error(
+          'Binary for Node.js version ' + version + ' is not available.'));
+      }
+      return cb();
+    });
+}
+
+
+function downloadAndInstallVersion(version, cb) {
+  var downloadUrl = 'https://storage.googleapis.com' +
+    '/gae_node_packages/node-' + version + '-linux-x64.tar.gz';
+  var destPath = '/nodejs';
+  var cmd = 'curl ' + downloadUrl + '| tar xzf - -C ' + destPath +
+    ' --strip-components=1';
+
+  exec('rm -rf ' + destPath + '/*', function(err) {
+    if (err) {
+      return cb(err);
+    }
+    exec(cmd, cb);
+  });
+}
+
+
+function fail(err) {
+  console.error('Node installation failed: ' + err.message);
+  process.exit(1);
+}
+
+
+function main(requestedVersion) {
+  // Does the current Node.js version already satisfy the requested version?
+  // If so, we have nothing to do.
+  if (semver.satisfies(process.version, requestedVersion)) {
+    return;
+  }
+
+  // Otherwise, find which version satisfies and install it.
+  getSatisfyingVersion(requestedVersion, function(err, version) {
+    if (err) {
+      return fail(err);
+    }
+    verifyBinaryExists(version, function(err) {
+      if (err) {
+        return fail(err);
+      }
+      downloadAndInstallVersion(version, function(err) {
+        if (err) {
+          return fail(err);
+        }
+        console.log('Installed Node.js ' + version);
+      });
+    });
+  });
+}
+
+var spec = process.argv[2];
+main(spec);


### PR DESCRIPTION
This script handles installing a user-requested node.js version.

The generated app dockerfile will need to include:

    RUN install_node %(version)s