### PR TITLE
Update to Node.js 4.4.5

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl pyth
     apt-get clean && rm /var/lib/apt/lists/*_*
 
 # Install the latest LTS release of nodejs
-RUN mkdir /nodejs && curl https://nodejs.org/dist/v4.4.4/node-v4.4.4-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
+RUN mkdir /nodejs && curl https://nodejs.org/dist/v4.4.5/node-v4.4.5-linux-x64.tar.gz | tar xvzf - -C /nodejs --strip-components=1
 ENV PATH $PATH:/nodejs/bin
 
 # Install semver, as required by the node version install script.


### PR DESCRIPTION
Upstream is at 4.4.5 already. Contains minor bugfixes, and a fix for a memory leak: https://github.com/nodejs/node/blob/v4.4.5/CHANGELOG.md#2016-05-24-version-445-argon-lts-thealphanerd.

Even though a security release might be coming down the pipe soon, we can use this release a way to test the release processes.

@JustinBeckwith PTAL.
