### PR TITLE
Switching base docker image from base to debian8

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
 # Use the base App Engine Docker image, based on debian jessie.
-FROM gcr.io/google_appengine/base
+FROM gcr.io/google_appengine/debian8
 
 # Install updates and dependencies
 RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential git ca-certificates libkrb5-dev && \


### PR DESCRIPTION
The newest debian images for jessie (gcr.io/google-appengine/debian8:latest) now has all the extra env variables and ca-certs that were in base.

cc @dlorenc