### PR TITLE
Revert changes to jenkins_build.sh

### DIFF
--- a/jenkins_build.sh
+++ b/jenkins_build.sh
@@ -9,9 +9,9 @@ envsubst < base/cloudbuild.yaml.in > base/cloudbuild.yaml
 gcloud beta container builds submit --config base/cloudbuild.yaml .
 
 if [ "${UPLOAD_TO_STAGING}" = "true" ]; then
-  gcloud beta container images add-tag ${IMAGE_NAME} ${DOCKER_NAMESPACE}/${RUNTIME_NAME}:staging -q
+  gcloud beta container images add-tag ${IMAGE} ${DOCKER_NAMESPACE}/${RUNTIME_NAME}:staging -q
 fi
 
 if [ ! -z "${NODE_VERSION_TAG}" ]; then
-  gcloud beta container images add-tag ${IMAGE_NAME} ${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${NODE_VERSION_TAG} -q
+  gcloud beta container images add-tag ${IMAGE} ${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${NODE_VERSION_TAG} -q
 fi

--- a/jenkins_build.sh
+++ b/jenkins_build.sh
@@ -2,16 +2,16 @@ RUNTIME_NAME="nodejs"
 
 CANDIDATE_NAME=`date +%Y-%m-%d_%H_%M`
 echo "CANDIDATE_NAME:${CANDIDATE_NAME}"
-export IMAGE="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${CANDIDATE_NAME}"
+IMAGE_NAME="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${CANDIDATE_NAME}"
 
 envsubst < base/cloudbuild.yaml.in > base/cloudbuild.yaml
 
-gcloud alpha container builds create --config base/cloudbuild.yaml .
+gcloud beta container builds submit --config base/cloudbuild.yaml .
 
 if [ "${UPLOAD_TO_STAGING}" = "true" ]; then
-  gcloud alpha container images add-tag ${IMAGE} ${DOCKER_NAMESPACE}/${RUNTIME_NAME}:staging -q
+  gcloud beta container images add-tag ${IMAGE_NAME} ${DOCKER_NAMESPACE}/${RUNTIME_NAME}:staging -q
 fi
 
 if [ ! -z "${NODE_VERSION_TAG}" ]; then
-  gcloud alpha container images add-tag ${IMAGE} ${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${NODE_VERSION_TAG} -q
+  gcloud beta container images add-tag ${IMAGE_NAME} ${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${NODE_VERSION_TAG} -q
 fi

--- a/jenkins_build.sh
+++ b/jenkins_build.sh
@@ -2,7 +2,7 @@ RUNTIME_NAME="nodejs"
 
 CANDIDATE_NAME=`date +%Y-%m-%d_%H_%M`
 echo "CANDIDATE_NAME:${CANDIDATE_NAME}"
-IMAGE_NAME="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${CANDIDATE_NAME}"
+export IMAGE="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${CANDIDATE_NAME}"
 
 envsubst < base/cloudbuild.yaml.in > base/cloudbuild.yaml
 


### PR DESCRIPTION
Previous changes to jenkins_build.sh referred to an older version of gcloud (when the components currently categorized as beta were under alpha). This change updates them back to the correct gcloud commands as of gcloud v135.0.0