### PR TITLE
Prevent gcloud container build from using cached images

### DIFF
--- a/base/cloudbuild.yaml.in
+++ b/base/cloudbuild.yaml.in
@@ -1,6 +1,6 @@
 steps:
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '--tag=${IMAGE}', './base']
+    args: ['build', '--tag=${IMAGE}', '--no-cache=true', './base']
     id: BUILD
   - name: gcr.io/gcp-runtimes/structure_test
     args: ['--image', '${IMAGE}',


### PR DESCRIPTION
gcloud container build shouldn't use previously cached images if security updates were released, since it may not pick them up. This change adds the docker build `--no-cache` flag to prevent that.

PTAL