### PR TITLE
Remove test containers on exit

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -33,7 +33,7 @@ describe('nodejs-docker', () => {
 function runDocker(tag, port, callback) {
   let name = uuid.v4();
   let d = spawn('docker', [
-    'run', '-i', '--name', name, '-p', `${port}:${port}`, tag
+    'run', '--rm', '-i', '--name', name, '-p', `${port}:${port}`, tag
   ]);
 
   d.stdout.on('data', (data) => {


### PR DESCRIPTION
Before this commit, containers started during the run of
`npm test` would be stopped but not removed.  That is, if
`docker ps -a` displayed no containers before running `npm test`
then `docker ps -a` would display one stopped container after
running `npm test`.

This commit fixes this issue so that if `docker ps -a` shows
no containers before running `npm test`, it will also show no
containers after running `npm test`.