### PR TITLE
jenkins_build.sh now outputs 'gcloud --version'

### DIFF
--- a/jenkins_build.sh
+++ b/jenkins_build.sh
@@ -1,3 +1,6 @@
+echo "gcloud --version"
+gcloud --version
+
 RUNTIME_NAME="nodejs"
 
 CANDIDATE_NAME=`date +%Y-%m-%d_%H_%M`


### PR DESCRIPTION
Now running `jenkins_build.sh` will output the version of `gcloud` for diagnostic purposes.