### PR TITLE
add license tests to structure tests

### DIFF
--- a/test/test_config.yaml
+++ b/test/test_config.yaml
@@ -26,4 +26,8 @@ fileExistenceTests:
 
 licenseTests:
 - debian: true
-  files: ['/nodejs/lib/node_modules/npm/LICENSE']
+  files: [
+          '/nodejs/lib/node_modules/npm/LICENSE',
+          '/nodejs/LICENSE',
+          '/nodejs/lib/node_modules/npm/node_modules/semver/LICENSE' 
+  ]

--- a/test/test_config.yaml
+++ b/test/test_config.yaml
@@ -23,3 +23,7 @@ fileExistenceTests:
   path: '/node_modules/semver'
   isDirectory: true
   shouldExist: true
+
+licenseTests:
+- debian: true
+  files: ['/nodejs/lib/node_modules/npm/LICENSE']


### PR DESCRIPTION
License tests are automated tests to check that all packages installed in the image conform to Google's open source licensing stardards. Check out https://github.com/GoogleCloudPlatform/runtimes-common/blob/master/structure_tests/licenses_test.go (and the corresponding README) for more details.