### PR TITLE
Update the Dockerfile to use npm to get semver

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir /nodejs && curl https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-x64.t
 ENV PATH $PATH:/nodejs/bin
 
 # Install semver, as required by the node version install script.
-RUN npm install https://storage.googleapis.com/gae_node_packages/semver.tar.gz
+RUN npm install semver
 
 # Add the node version install script
 ADD install_node /usr/local/bin/install_node

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,7 +10,11 @@ RUN mkdir /nodejs && curl https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-x64.t
 ENV PATH $PATH:/nodejs/bin
 
 # Install semver, as required by the node version install script.
-RUN npm install semver
+# The use of --unsafe-perm is used here so that the installation is done
+# as the current (root) user.  Otherwise, a failure in running 'npm install'
+# (for example through a failure in a pre-or-post install hook) won't cause
+# npm install to have a non-zero exit code.
+RUN npm install --unsafe-perm semver
 
 # Add the node version install script
 ADD install_node /usr/local/bin/install_node


### PR DESCRIPTION
I have verified that the existing testing framework already tests for the existence of `semver` in the `fileExistenceTests` section of `test_config.yaml`.

I am still looking for an api that `npm` exposes to get the location from where `npm` acquired the `semver` it installed.  However, I verified manually that the `Dockerfile` does `semver` correctly from the `npm` repo.