### PR TITLE
Add netbase in the base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,7 +2,7 @@
 FROM gcr.io/google_appengine/debian8
 
 # Install updates and dependencies
-RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential git ca-certificates libkrb5-dev imagemagick && \
+RUN apt-get update -y && apt-get install --no-install-recommends -y -q curl python build-essential git ca-certificates libkrb5-dev imagemagick netbase && \
     apt-get clean && rm /var/lib/apt/lists/*_*
 
 # Install the latest LTS release of nodejs


### PR DESCRIPTION
gRPC@1.1.1 cannot deal with the lack of /etc/services.

https://github.com/GoogleCloudPlatform/google-cloud-node/issues/1946#issuecomment-277298320