### PR TITLE
Change the repository of runtime builder steps

### DIFF
--- a/builder/bin/local_build.sh
+++ b/builder/bin/local_build.sh
@@ -15,12 +15,12 @@ UPLOAD_TO_STAGING="false"
 ${BASE}/bin/build.sh ${BUILDER_NAMESPACE} ${BUILDER_TAG} ${UPLOAD_TO_STAGING}
 
 # Tag the built image as 'latest'
-TAG_OF_LATEST=$(gcloud beta container images list-tags ${BUILDER_NAMESPACE}/nodejs-gen-dockerfile --sort-by=~timestamp --limit=1 --format='get(tags)')
-gcloud --quiet beta container images add-tag ${BUILDER_NAMESPACE}/nodejs-gen-dockerfile:${TAG_OF_LATEST} ${BUILDER_NAMESPACE}/nodejs-gen-dockerfile:latest
+TAG_OF_LATEST=$(gcloud beta container images list-tags ${BUILDER_NAMESPACE}/nodejs/gen-dockerfile --sort-by=~timestamp --limit=1 --format='get(tags)')
+gcloud --quiet beta container images add-tag ${BUILDER_NAMESPACE}/nodejs/gen-dockerfile:${TAG_OF_LATEST} ${BUILDER_NAMESPACE}/nodejs/gen-dockerfile:latest
 
 rm -Rf ${LOCAL_BUILDS}
 mkdir ${LOCAL_BUILDS}
 
 # Store a version of nodejs.yaml that is updated to use the current gcloud's project's GCR
-sed "s|gcr.io/gcp-runtimes/nodejs-gen-dockerfile:latest|${BUILDER_NAMESPACE}/nodejs-gen-dockerfile:latest|g" ${BASE}/nodejs.yaml > ${LOCAL_BUILDS}/nodejs-${BUILDER_TAG}.yaml
+sed "s|gcr.io/gcp-runtimes/nodejs/gen-dockerfile:latest|${BUILDER_NAMESPACE}/nodejs/gen-dockerfile:latest|g" ${BASE}/nodejs.yaml > ${LOCAL_BUILDS}/nodejs-${BUILDER_TAG}.yaml
 echo ${BUILDER_TAG} > ${LOCAL_BUILDS}/nodejs.version

--- a/builder/nodejs.yaml
+++ b/builder/nodejs.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: 'gcr.io/gcp-runtimes/nodejs-gen-dockerfile:latest'
+  - name: 'gcr.io/gcp-runtimes/nodejs/gen-dockerfile:latest'
     args: ['--base-image', 'gcr.io/google-appengine/nodejs:latest']
   - name: 'gcr.io/cloud_builders/docker'
     args: ['build', '-t', '$_OUTPUT_IMAGE', '.']

--- a/builder/steps/gen-dockerfile/build.sh
+++ b/builder/steps/gen-dockerfile/build.sh
@@ -17,7 +17,7 @@
 # Fail fast
 set -e
 
-RUNTIME_NAME="nodejs-gen-dockerfile"
+RUNTIME_NAME="gen-dockerfile"
 
 BUILDER_NAMESPACE=${1}
 BUILDER_TAG=${2}
@@ -28,7 +28,7 @@ if [ -z "${BUILDER_NAMESPACE}" -o -z "${BUILDER_TAG}" -o -z "${UPLOAD_TO_STAGING
   exit 1
 fi
 
-UNTAGGED_BUILDER_NAME=${BUILDER_NAMESPACE}/${RUNTIME_NAME}
+UNTAGGED_BUILDER_NAME=${BUILDER_NAMESPACE}/nodejs/${RUNTIME_NAME}
 
 # This is exported so that they can be used in cloudbuild.yaml.in
 export IMAGE="${UNTAGGED_BUILDER_NAME}:${BUILDER_TAG}"


### PR DESCRIPTION
Now runtime builder steps will reside in `gcr.io/gcp-runtimes/nodejs`.
