### PR TITLE
Pin all Docker names in nodejs.yaml to a tag

### DIFF
--- a/builder/nodejs.yaml
+++ b/builder/nodejs.yaml
@@ -1,7 +1,7 @@
 steps:
   - name: 'gcr.io/gcp-runtimes/nodejs/gen-dockerfile:latest'
     args: ['--base-image', 'gcr.io/google-appengine/nodejs:latest']
-  - name: 'gcr.io/cloud_builders/docker'
+  - name: 'gcr.io/cloud_builders/docker:latest'
     args: ['build', '-t', '$_OUTPUT_IMAGE', '.']
 
 images:


### PR DESCRIPTION
It is a requirement that all Docker names specified in the `builder/nodejs.yaml` file explicitly specify a tag.