### PR TITLE
Fix `jenkins_build.sh` not building the base image

### DIFF
--- a/jenkins_build.sh
+++ b/jenkins_build.sh
@@ -16,7 +16,7 @@ export IMAGE="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${CANDIDATE_NAME}"
 
 envsubst < base/cloudbuild.yaml.in > base/cloudbuild.yaml
 
-gcloud beta container builds submit --config base/cloudbuild.yaml .
+gcloud beta container builds submit --config base/cloudbuild.yaml base
 
 if [ "${UPLOAD_TO_STAGING}" = "true" ]; then
   gcloud beta container images add-tag ${IMAGE} ${DOCKER_NAMESPACE}/${RUNTIME_NAME}:staging -q


### PR DESCRIPTION
The `gcloud beta container builds submit` was given the wrong
directory.  That directory didn't contain a `Dockerfile`, and thus
the build would fail.