### PR TITLE
Fix a failure to deploy if using yarn

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -18,7 +18,7 @@ ENV PATH $PATH:/nodejs/bin
 RUN npm install --unsafe-perm semver
 
 # Install yarn here so users don't have to manually install it.
-RUN npm install --unsafe-perm --global yarn
+RUN npm install --unsafe-perm yarn
 
 # Add the node version install script
 ADD contents/install_node /usr/local/bin/install_node

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -17,9 +17,6 @@ ENV PATH $PATH:/nodejs/bin
 # Install semver as required by the node version install script.
 RUN npm install --unsafe-perm semver
 
-# Install yarn here so users don't have to manually install it.
-RUN npm install --unsafe-perm yarn
-
 # Add the node version install script
 ADD contents/install_node /usr/local/bin/install_node
 

--- a/base/test/test_config.yaml
+++ b/base/test/test_config.yaml
@@ -25,14 +25,14 @@ fileExistenceTests:
   shouldExist: true
 
 - name: 'yarn'
-  path: '/nodejs/bin'
+  path: '/nodejs/bin/yarn'
   isDirectory: false
-  shouldExist: true
+  shouldExist: false
 
 licenseTests:
 - debian: true
   files: [
           '/nodejs/lib/node_modules/npm/LICENSE',
           '/nodejs/LICENSE',
-          '/nodejs/lib/node_modules/npm/node_modules/semver/LICENSE' 
+          '/nodejs/lib/node_modules/npm/node_modules/semver/LICENSE'
   ]


### PR DESCRIPTION
This was caused by the fact that this repo's base image contains
a global install of `yarn`.

This installation of `yarn` is correct, and `yarn` can be used
in images that derive from the base image.

Further, if a global install of `yarn` is done during the building
of an image that derives from the base image in this repo, the
`yarn` installation will return an exit code indicating it did
succeed.  However, the `node_modules` dependencies for `yarn` will
not exist in the container.  As a result, `yarn` will not be able
to run.

This issue is actually not specific to `yarn`.  If, during the
build process of a Docker image, any package is installed globally
using `npm` and then installed globally again (in that image or a
derived image), the installation will not include the package's
dependencies.

The fix involves removing the global install of `yarn` in the
base image since it is nice to have, but not a strict requirement.