### PR TITLE
Remove manually running `node server.js`

### DIFF
--- a/builder/steps/gen-dockerfile/contents/data/Dockerfile.txt
+++ b/builder/steps/gen-dockerfile/contents/data/Dockerfile.txt
@@ -31,8 +31,4 @@ RUN npm install --unsafe-perm || \
   <% } %>
 <% } %>
 
-<% if (config.gotScriptsStart) { %>
 CMD <%- tool %> start
-<% } else { %>
-CMD node server.js
-<% } %>

--- a/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
+++ b/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
@@ -40,11 +40,6 @@ export interface Setup {
    */
   canInstallDeps: boolean;
   /**
-   * Specifies whether the app directory's package.json file contains a
-   * "scripts" section that contains a "start" command
-   */
-  gotScriptsStart: boolean;
-  /**
    * Specifies the semver expression representing the version of Node.js used
    * to run the application as specified by the application's package.json file
    */
@@ -165,7 +160,6 @@ export async function detectSetup(
   // extend filters undefined properties.
   const setup = extend({}, {
     canInstallDeps: canInstallDeps,
-    gotScriptsStart: gotScriptsStart,
     nodeVersion: nodeVersion ? shellEscape([nodeVersion]) : undefined,
     useYarn: useYarn
   });

--- a/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
@@ -101,7 +101,7 @@ describe('detectSetup', () => {
           {path: 'server.js', exists: true, contents: 'some content'}
         ],
         ['Checking for Node.js.', 'node.js checker: No package.json file.'], [],
-        {canInstallDeps: false, gotScriptsStart: false, useYarn: false});
+        {canInstallDeps: false, useYarn: false});
 
     performTest(
         'should detect with package.json, without a start script, ' +
@@ -119,7 +119,7 @@ describe('detectSetup', () => {
               'version, see ' +
               'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
         ],
-        {canInstallDeps: true, gotScriptsStart: false, useYarn: false});
+        {canInstallDeps: true, useYarn: false});
 
     performTest(
         'should detect with package.json, without a start script, ' +
@@ -141,7 +141,7 @@ describe('detectSetup', () => {
               'version, see ' +
               'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
         ],
-        {canInstallDeps: true, gotScriptsStart: false, useYarn: false});
+        {canInstallDeps: true, useYarn: false});
 
     performTest(
         'should detect with package.json, without a start script, ' +
@@ -159,7 +159,7 @@ describe('detectSetup', () => {
               'version, see ' +
               'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
         ],
-        {canInstallDeps: true, gotScriptsStart: false, useYarn: true});
+        {canInstallDeps: true, useYarn: true});
 
     performTest(
         'should detect with package.json, with start script, ' +
@@ -180,7 +180,7 @@ describe('detectSetup', () => {
               'version, see ' +
               'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
         ],
-        {canInstallDeps: true, gotScriptsStart: true, useYarn: false});
+        {canInstallDeps: true, useYarn: false});
 
     performTest(
         'should detect with package.json, with start script, ' +
@@ -206,7 +206,7 @@ describe('detectSetup', () => {
               'version, see ' +
               'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
         ],
-        {canInstallDeps: true, gotScriptsStart: true, useYarn: false});
+        {canInstallDeps: true, useYarn: false});
 
     performTest(
         'should detect with package.json, with start script, ' +
@@ -227,6 +227,6 @@ describe('detectSetup', () => {
               'version, see ' +
               'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
         ],
-        {canInstallDeps: true, gotScriptsStart: true, useYarn: true});
+        {canInstallDeps: true, useYarn: true});
   });
 });

--- a/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
@@ -104,8 +104,8 @@ describe('detectSetup', () => {
         {canInstallDeps: false, useYarn: false});
 
     performTest(
-        'should detect with package.json, without a start script, ' +
-            'without yarn.lock, and with server.js',
+        'should detect with package.json, without yarn.lock, and with ' +
+            'server.js',
         [
           {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
           {path: 'package.json', exists: true, contents: '{}'},
@@ -122,8 +122,8 @@ describe('detectSetup', () => {
         {canInstallDeps: true, useYarn: false});
 
     performTest(
-        'should detect with package.json, without a start script, ' +
-            'with yarn.lock, with yarn.lock skipped, and with server.js',
+        'should detect with package.json, with yarn.lock, with yarn.lock ' +
+            'skipped, and with server.js',
         [
           {
             path: 'app.yaml',
@@ -162,8 +162,8 @@ describe('detectSetup', () => {
         {canInstallDeps: true, useYarn: true});
 
     performTest(
-        'should detect with package.json, with start script, ' +
-            'without yarn.lock, and with server.js',
+        'should detect with package.json, without yarn.lock, ' +
+            'and with server.js',
         [
           {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS}, {
             path: 'package.json',
@@ -183,8 +183,8 @@ describe('detectSetup', () => {
         {canInstallDeps: true, useYarn: false});
 
     performTest(
-        'should detect with package.json, with start script, ' +
-            'with yarn.lock, with yarn.lock skipped, and without server.js',
+        'should detect with package.json, with yarn.lock, with yarn.lock ' +
+            'skipped, and without server.js',
         [
           {
             path: 'app.yaml',
@@ -209,8 +209,8 @@ describe('detectSetup', () => {
         {canInstallDeps: true, useYarn: false});
 
     performTest(
-        'should detect with package.json, with start script, ' +
-            'with yarn.lock, and without server.js',
+        'should detect with package.json, with yarn.lock, and without ' +
+            'server.js',
         [
           {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS}, {
             path: 'package.json',

--- a/builder/steps/gen-dockerfile/contents/test/generate_files_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/generate_files_test.ts
@@ -65,7 +65,6 @@ const YARN_INSTALL_DEPS = `RUN yarn install --production || \\
 
 const YARN_START = `CMD yarn start\n`;
 const NPM_START = `CMD npm start\n`;
-const SERVER_START = `CMD node server.js\n`;
 
 async function runTest(
     config: Setup, expectedDockerfile: string, expectedDockerignore: string) {
@@ -99,25 +98,15 @@ describe('generateFiles', async () => {
   it('should generate correctly without installing dependencies, without start script, without Node.version, and using npm',
      async () => {
        await runTest(
-           {
-             canInstallDeps: false,
-             gotScriptsStart: false,
-             nodeVersion: undefined,
-             useYarn: false
-           },
-           BASE + COPY_CONTENTS + SERVER_START, DOCKERIGNORE);
+           {canInstallDeps: false, nodeVersion: undefined, useYarn: false},
+           BASE + COPY_CONTENTS + NPM_START, DOCKERIGNORE);
      });
 
   it('should generate correctly without installing dependencies, without start script, without Node.version, and using yarn',
      async () => {
        await runTest(
-           {
-             canInstallDeps: false,
-             gotScriptsStart: false,
-             nodeVersion: undefined,
-             useYarn: true
-           },
-           BASE + COPY_CONTENTS + SERVER_START, DOCKERIGNORE);
+           {canInstallDeps: false, nodeVersion: undefined, useYarn: true},
+           BASE + COPY_CONTENTS + YARN_START, DOCKERIGNORE);
      });
 
   it('should generate correctly without installing dependencies, without start script, with Node.version, and using npm',
@@ -125,160 +114,95 @@ describe('generateFiles', async () => {
        await runTest(
            {
              canInstallDeps: false,
-             gotScriptsStart: false,
              nodeVersion: NODE_VERSION,
              useYarn: false,
            },
-           BASE + UPGRADE_NODE + COPY_CONTENTS + SERVER_START, DOCKERIGNORE);
+           BASE + UPGRADE_NODE + COPY_CONTENTS + NPM_START, DOCKERIGNORE);
      });
 
   it('should generate correctly without installing dependencies, without start script, with Node.version, and using yarn',
      async () => {
        await runTest(
-           {
-             canInstallDeps: false,
-             gotScriptsStart: false,
-             nodeVersion: NODE_VERSION,
-             useYarn: true
-           },
-           BASE + UPGRADE_NODE + COPY_CONTENTS + SERVER_START, DOCKERIGNORE);
+           {canInstallDeps: false, nodeVersion: NODE_VERSION, useYarn: true},
+           BASE + UPGRADE_NODE + COPY_CONTENTS + YARN_START, DOCKERIGNORE);
      });
 
   it('should generate correctly without installing dependencies, with start script, without Node.version, and using npm',
      async () => {
        await runTest(
-           {
-             canInstallDeps: false,
-             gotScriptsStart: true,
-             nodeVersion: undefined,
-             useYarn: false
-           },
+           {canInstallDeps: false, nodeVersion: undefined, useYarn: false},
            BASE + COPY_CONTENTS + NPM_START, DOCKERIGNORE);
      });
 
   it('should generate correctly without installing dependencies, with start script, without Node.version, and using yarn',
      async () => {
        await runTest(
-           {
-             canInstallDeps: false,
-             gotScriptsStart: true,
-             nodeVersion: undefined,
-             useYarn: true
-           },
+           {canInstallDeps: false, nodeVersion: undefined, useYarn: true},
            BASE + COPY_CONTENTS + YARN_START, DOCKERIGNORE);
      });
 
   it('should generate correctly without installing dependencies, with start script, with Node.version, and using npm',
      async () => {
        await runTest(
-           {
-             canInstallDeps: false,
-             gotScriptsStart: true,
-             nodeVersion: NODE_VERSION,
-             useYarn: false
-           },
+           {canInstallDeps: false, nodeVersion: NODE_VERSION, useYarn: false},
            BASE + UPGRADE_NODE + COPY_CONTENTS + NPM_START, DOCKERIGNORE);
      });
 
   it('should generate correctly without installing dependencies, with start script, with Node.version, and using yarn',
      async () => {
        await runTest(
-           {
-             canInstallDeps: false,
-             gotScriptsStart: true,
-             nodeVersion: NODE_VERSION,
-             useYarn: true
-           },
+           {canInstallDeps: false, nodeVersion: NODE_VERSION, useYarn: true},
            BASE + UPGRADE_NODE + COPY_CONTENTS + YARN_START, DOCKERIGNORE);
      });
 
   it('should generate correctly with installing dependencies, without start script, without Node.version, and using npm',
      async () => {
        await runTest(
-           {
-             canInstallDeps: true,
-             gotScriptsStart: false,
-             nodeVersion: undefined,
-             useYarn: false
-           },
-           BASE + COPY_CONTENTS + NPM_INSTALL_DEPS + SERVER_START,
-           DOCKERIGNORE);
+           {canInstallDeps: true, nodeVersion: undefined, useYarn: false},
+           BASE + COPY_CONTENTS + NPM_INSTALL_DEPS + NPM_START, DOCKERIGNORE);
      });
 
   it('should generate correctly with installing dependencies, without start script, without Node.version, and using yarn',
      async () => {
        await runTest(
-           {
-             canInstallDeps: true,
-             gotScriptsStart: false,
-             nodeVersion: undefined,
-             useYarn: true
-           },
-           BASE + COPY_CONTENTS + YARN_INSTALL_DEPS + SERVER_START,
-           DOCKERIGNORE);
+           {canInstallDeps: true, nodeVersion: undefined, useYarn: true},
+           BASE + COPY_CONTENTS + YARN_INSTALL_DEPS + YARN_START, DOCKERIGNORE);
      });
 
   it('should generate correctly with installing dependencies, without start script, with Node.version, and using npm',
      async () => {
        await runTest(
-           {
-             canInstallDeps: true,
-             gotScriptsStart: false,
-             nodeVersion: NODE_VERSION,
-             useYarn: false
-           },
-           BASE + UPGRADE_NODE + COPY_CONTENTS + NPM_INSTALL_DEPS +
-               SERVER_START,
+           {canInstallDeps: true, nodeVersion: NODE_VERSION, useYarn: false},
+           BASE + UPGRADE_NODE + COPY_CONTENTS + NPM_INSTALL_DEPS + NPM_START,
            DOCKERIGNORE);
      });
 
   it('should generate correctly with installing dependencies, without start script, with Node.version, and using yarn',
      async () => {
        await runTest(
-           {
-             canInstallDeps: true,
-             gotScriptsStart: false,
-             nodeVersion: NODE_VERSION,
-             useYarn: true
-           },
-           BASE + UPGRADE_NODE + COPY_CONTENTS + YARN_INSTALL_DEPS +
-               SERVER_START,
+           {canInstallDeps: true, nodeVersion: NODE_VERSION, useYarn: true},
+           BASE + UPGRADE_NODE + COPY_CONTENTS + YARN_INSTALL_DEPS + YARN_START,
            DOCKERIGNORE);
      });
 
   it('should generate correctly with installing dependencies, with start script, without Node.version, and using npm',
      async () => {
        await runTest(
-           {
-             canInstallDeps: true,
-             gotScriptsStart: true,
-             nodeVersion: undefined,
-             useYarn: false
-           },
+           {canInstallDeps: true, nodeVersion: undefined, useYarn: false},
            BASE + COPY_CONTENTS + NPM_INSTALL_DEPS + NPM_START, DOCKERIGNORE);
      });
 
   it('should generate correctly with installing dependencies, with start script, without Node.version, and using yarn',
      async () => {
        await runTest(
-           {
-             canInstallDeps: true,
-             gotScriptsStart: true,
-             nodeVersion: undefined,
-             useYarn: true
-           },
+           {canInstallDeps: true, nodeVersion: undefined, useYarn: true},
            BASE + COPY_CONTENTS + YARN_INSTALL_DEPS + YARN_START, DOCKERIGNORE);
      });
 
   it('should generate correctly with installing dependencies, with start script, with Node.version, and using npm',
      async () => {
        await runTest(
-           {
-             canInstallDeps: true,
-             gotScriptsStart: true,
-             nodeVersion: NODE_VERSION,
-             useYarn: false
-           },
+           {canInstallDeps: true, nodeVersion: NODE_VERSION, useYarn: false},
            BASE + UPGRADE_NODE + COPY_CONTENTS + NPM_INSTALL_DEPS + NPM_START,
            DOCKERIGNORE);
      });
@@ -286,12 +210,7 @@ describe('generateFiles', async () => {
   it('should generate correctly with installing dependencies, with start script, with Node.version, and using yarn',
      async () => {
        await runTest(
-           {
-             canInstallDeps: true,
-             gotScriptsStart: true,
-             nodeVersion: NODE_VERSION,
-             useYarn: true
-           },
+           {canInstallDeps: true, nodeVersion: NODE_VERSION, useYarn: true},
            BASE + UPGRADE_NODE + COPY_CONTENTS + YARN_INSTALL_DEPS + YARN_START,
            DOCKERIGNORE);
      });


### PR DESCRIPTION
Previously, if the `package.json` file did not contain a `start`
script, the application was started by calling `node server.js`.

Now, `npm start` or `yarn start` is always called to start the
application because those tools, themselves, already run
`node server.js` if a `start` script is not available in
`package.json`.