### PR TITLE
Install npm as per engines.npm

### DIFF
--- a/builder/steps/gen-dockerfile/contents/data/Dockerfile.txt
+++ b/builder/steps/gen-dockerfile/contents/data/Dockerfile.txt
@@ -8,6 +8,12 @@ FROM <%- baseImage %>
 RUN /usr/local/bin/install_node '<%- config.nodeVersion %>'
 <% } %>
 
+<% if (config.npmVersion) { %>
+# Install the version of npm as requested by the engines.npm field in
+# package.json.
+RUN npm install -g 'npm@<%- config.npmVersion %>'
+<% } %>
+
 COPY . /app/
 
 <% if (config.canInstallDeps) { %>

--- a/builder/steps/gen-dockerfile/contents/gulpfile.js
+++ b/builder/steps/gen-dockerfile/contents/gulpfile.js
@@ -94,8 +94,7 @@ gulp.task('test.compile', ['compile'], function() {
 });
 
 gulp.task('test.unit', ['test.compile'], function() {
-  return gulp.src([outDir + '/test/**/*.js'])
-      .pipe(mocha({reporter: 'spec', require: 'source-map-support/register'}));
+  return gulp.src([outDir + '/test/**/*.js']).pipe(mocha({reporter: 'spec'}));
 });
 
 gulp.task('watch', function() {

--- a/builder/steps/gen-dockerfile/contents/gulpfile.js
+++ b/builder/steps/gen-dockerfile/contents/gulpfile.js
@@ -94,7 +94,8 @@ gulp.task('test.compile', ['compile'], function() {
 });
 
 gulp.task('test.unit', ['test.compile'], function() {
-  return gulp.src([outDir + '/test/**/*.js']).pipe(mocha({reporter: 'spec'}));
+  return gulp.src([outDir + '/test/**/*.js'])
+      .pipe(mocha({reporter: 'spec', require: 'source-map-support/register'}));
 });
 
 gulp.task('watch', function() {

--- a/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
+++ b/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
@@ -40,6 +40,11 @@ export interface Setup {
    */
   canInstallDeps: boolean;
   /**
+   * Specifies the semver expression representing the version of npm to be
+   * installed, as specified by the application's package.json file.
+   */
+  npmVersion?: string;
+  /**
    * Specifies the semver expression representing the version of Node.js used
    * to run the application as specified by the application's package.json file
    */
@@ -92,6 +97,7 @@ export async function detectSetup(
 
   let canInstallDeps: boolean;
   let gotScriptsStart: boolean;
+  let npmVersion: string|undefined;
   let nodeVersion: string|undefined;
   let useYarn: boolean;
 
@@ -133,14 +139,11 @@ export async function detectSetup(
     // See if we've got a scripts.start field.
     gotScriptsStart = !!(packageJson.scripts && packageJson.scripts.start);
 
-    // See if a version of node is specified.
-    if (packageJson.engines && packageJson.engines.node) {
-      nodeVersion = packageJson.engines.node;
-    } else {
-      nodeVersion = undefined;
-      warn(
-          'node.js checker: ignoring invalid "engines" field in ' +
-          'package.json');
+    // Check if the user has specified specific versions of node or npm in the
+    // package.json.
+    if (packageJson.engines) {
+      nodeVersion = packageJson.engines.node || undefined;
+      npmVersion = packageJson.engines.npm || undefined;
     }
 
     if (!nodeVersion) {
@@ -160,6 +163,7 @@ export async function detectSetup(
   // extend filters undefined properties.
   const setup = extend({}, {
     canInstallDeps: canInstallDeps,
+    npmVersion: npmVersion ? shellEscape([npmVersion]) : undefined,
     nodeVersion: nodeVersion ? shellEscape([nodeVersion]) : undefined,
     useYarn: useYarn
   });

--- a/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
+++ b/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
@@ -142,8 +142,8 @@ export async function detectSetup(
     // Check if the user has specified specific versions of node or npm in the
     // package.json.
     if (packageJson.engines) {
-      nodeVersion = packageJson.engines.node || undefined;
-      npmVersion = packageJson.engines.npm || undefined;
+      nodeVersion = packageJson.engines.node;
+      npmVersion = packageJson.engines.npm;
     }
 
     if (!nodeVersion) {

--- a/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+// Describe the signature of function exported by the `shell-escape` module
+// so the compiler knows what types to expect and return.  This is needed
+// since the `shell-escape` module does not have type definitions available.
+const shellEscape: (args: string[]) => string = require('shell-escape');
+
 import * as assert from 'assert';
 
 import {detectSetup, Setup} from '../src/detect_setup';
@@ -113,12 +118,9 @@ describe('detectSetup', () => {
           {path: 'yarn.lock', exists: false}
         ],
         ['Checking for Node.js.'],
-        [
-          'node.js checker: ignoring invalid "engines" field in package.json',
-          'No node version specified.  Please add your node ' +
-              'version, see ' +
-              'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
-        ],
+        ['No node version specified.  Please add your node ' +
+         'version, see ' +
+         'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'],
         {canInstallDeps: true, useYarn: false});
 
     performTest(
@@ -135,12 +137,9 @@ describe('detectSetup', () => {
           {path: 'yarn.lock', exists: true, contents: 'some contents'}
         ],
         ['Checking for Node.js.'],
-        [
-          'node.js checker: ignoring invalid "engines" field in package.json',
-          'No node version specified.  Please add your node ' +
-              'version, see ' +
-              'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
-        ],
+        ['No node version specified.  Please add your node ' +
+         'version, see ' +
+         'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'],
         {canInstallDeps: true, useYarn: false});
 
     performTest(
@@ -153,12 +152,9 @@ describe('detectSetup', () => {
           {path: 'yarn.lock', exists: true, contents: 'some content'}
         ],
         ['Checking for Node.js.'],
-        [
-          'node.js checker: ignoring invalid "engines" field in package.json',
-          'No node version specified.  Please add your node ' +
-              'version, see ' +
-              'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
-        ],
+        ['No node version specified.  Please add your node ' +
+         'version, see ' +
+         'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'],
         {canInstallDeps: true, useYarn: true});
 
     performTest(
@@ -174,12 +170,9 @@ describe('detectSetup', () => {
           {path: 'yarn.lock', exists: false}
         ],
         ['Checking for Node.js.'],
-        [
-          'node.js checker: ignoring invalid "engines" field in package.json',
-          'No node version specified.  Please add your node ' +
-              'version, see ' +
-              'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
-        ],
+        ['No node version specified.  Please add your node ' +
+         'version, see ' +
+         'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'],
         {canInstallDeps: true, useYarn: false});
 
     performTest(
@@ -200,12 +193,9 @@ describe('detectSetup', () => {
           {path: 'yarn.lock', exists: true, contents: 'some contents'}
         ],
         ['Checking for Node.js.'],
-        [
-          'node.js checker: ignoring invalid "engines" field in package.json',
-          'No node version specified.  Please add your node ' +
-              'version, see ' +
-              'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
-        ],
+        ['No node version specified.  Please add your node ' +
+         'version, see ' +
+         'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'],
         {canInstallDeps: true, useYarn: false});
 
     performTest(
@@ -221,12 +211,52 @@ describe('detectSetup', () => {
           {path: 'yarn.lock', exists: true, contents: 'some content'}
         ],
         ['Checking for Node.js.'],
+        ['No node version specified.  Please add your node ' +
+         'version, see ' +
+         'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'],
+        {canInstallDeps: true, gotScriptsStart: true, useYarn: true});
+
+    performTest(
+        'should detect node version from the engines field in package.json',
         [
-          'node.js checker: ignoring invalid "engines" field in package.json',
+          {
+            path: 'package.json',
+            exists: true,
+            contents: JSON.stringify(
+                {engines: {node: '^3.3.8'}, scripts: {start: 'npm start'}})
+          },
+          {path: 'app.yaml', exists: true, contents: 'some contents'},
+          {path: 'yarn.lock', exists: false}
+        ],
+        ['Checking for Node.js.'], [], {
+          canInstallDeps: true,
+          gotScriptsStart: true,
+          nodeVersion: shellEscape(['^3.3.8']),
+          useYarn: false
+        });
+
+    performTest(
+        'should detect npm version from the engines field in package.json',
+        [
+          {
+            path: 'package.json',
+            exists: true,
+            contents: JSON.stringify(
+                {engines: {npm: '5.x'}, scripts: {start: 'npm start'}})
+          },
+          {path: 'app.yaml', exists: true, contents: 'some contents'},
+          {path: 'yarn.lock', exists: false}
+        ],
+        [
+          'Checking for Node.js.',
           'No node version specified.  Please add your node ' +
               'version, see ' +
               'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
         ],
-        {canInstallDeps: true, useYarn: true});
+        [], {
+          canInstallDeps: true,
+          npmVersion: shellEscape(['5.x']),
+          useYarn: false
+        });
   });
 });

--- a/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
@@ -214,7 +214,7 @@ describe('detectSetup', () => {
         ['No node version specified.  Please add your node ' +
          'version, see ' +
          'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'],
-        {canInstallDeps: true, gotScriptsStart: true, useYarn: true});
+        {canInstallDeps: true, useYarn: true});
 
     performTest(
         'should detect node version from the engines field in package.json',
@@ -230,7 +230,6 @@ describe('detectSetup', () => {
         ],
         ['Checking for Node.js.'], [], {
           canInstallDeps: true,
-          gotScriptsStart: true,
           nodeVersion: shellEscape(['^3.3.8']),
           useYarn: false
         });

--- a/builder/steps/gen-dockerfile/contents/test/generate_files_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/generate_files_test.ts
@@ -27,6 +27,7 @@ const DOCKERIGNORE_NAME = '.dockerignore';
 
 const BASE_IMAGE = 'some-namespace:some-tag';
 const NODE_VERSION = 'v6.10.0';
+const NPM_VERSION = '^5.0.2';
 
 const BASE =
     `# Dockerfile extending the generic Node image with application files for a
@@ -40,6 +41,12 @@ const UPGRADE_NODE =
      NODE_VERSION
    }' and, if not, install a version of Node.js that does satisfy it.
 RUN /usr/local/bin/install_node '${NODE_VERSION}'
+`;
+
+const INSTALL_NPM =
+    `# Install the version of npm as requested by the engines.npm field in
+# package.json.
+RUN npm install -g 'npm@${NPM_VERSION}'
 `;
 
 const COPY_CONTENTS = `COPY . /app/\n`;
@@ -98,14 +105,14 @@ describe('generateFiles', async () => {
   it('should generate correctly without installing dependencies, without start script, without Node.version, and using npm',
      async () => {
        await runTest(
-           {canInstallDeps: false, nodeVersion: undefined, useYarn: false},
+           {canInstallDeps: false, useYarn: false},
            BASE + COPY_CONTENTS + NPM_START, DOCKERIGNORE);
      });
 
   it('should generate correctly without installing dependencies, without start script, without Node.version, and using yarn',
      async () => {
        await runTest(
-           {canInstallDeps: false, nodeVersion: undefined, useYarn: true},
+           {canInstallDeps: false, useYarn: true},
            BASE + COPY_CONTENTS + YARN_START, DOCKERIGNORE);
      });
 
@@ -130,14 +137,14 @@ describe('generateFiles', async () => {
   it('should generate correctly without installing dependencies, with start script, without Node.version, and using npm',
      async () => {
        await runTest(
-           {canInstallDeps: false, nodeVersion: undefined, useYarn: false},
+           {canInstallDeps: false, useYarn: false},
            BASE + COPY_CONTENTS + NPM_START, DOCKERIGNORE);
      });
 
   it('should generate correctly without installing dependencies, with start script, without Node.version, and using yarn',
      async () => {
        await runTest(
-           {canInstallDeps: false, nodeVersion: undefined, useYarn: true},
+           {canInstallDeps: false, useYarn: true},
            BASE + COPY_CONTENTS + YARN_START, DOCKERIGNORE);
      });
 
@@ -158,14 +165,14 @@ describe('generateFiles', async () => {
   it('should generate correctly with installing dependencies, without start script, without Node.version, and using npm',
      async () => {
        await runTest(
-           {canInstallDeps: true, nodeVersion: undefined, useYarn: false},
+           {canInstallDeps: true, useYarn: false},
            BASE + COPY_CONTENTS + NPM_INSTALL_DEPS + NPM_START, DOCKERIGNORE);
      });
 
   it('should generate correctly with installing dependencies, without start script, without Node.version, and using yarn',
      async () => {
        await runTest(
-           {canInstallDeps: true, nodeVersion: undefined, useYarn: true},
+           {canInstallDeps: true, useYarn: true},
            BASE + COPY_CONTENTS + YARN_INSTALL_DEPS + YARN_START, DOCKERIGNORE);
      });
 
@@ -188,14 +195,14 @@ describe('generateFiles', async () => {
   it('should generate correctly with installing dependencies, with start script, without Node.version, and using npm',
      async () => {
        await runTest(
-           {canInstallDeps: true, nodeVersion: undefined, useYarn: false},
+           {canInstallDeps: true, useYarn: false},
            BASE + COPY_CONTENTS + NPM_INSTALL_DEPS + NPM_START, DOCKERIGNORE);
      });
 
   it('should generate correctly with installing dependencies, with start script, without Node.version, and using yarn',
      async () => {
        await runTest(
-           {canInstallDeps: true, nodeVersion: undefined, useYarn: true},
+           {canInstallDeps: true, useYarn: true},
            BASE + COPY_CONTENTS + YARN_INSTALL_DEPS + YARN_START, DOCKERIGNORE);
      });
 
@@ -214,4 +221,17 @@ describe('generateFiles', async () => {
            BASE + UPGRADE_NODE + COPY_CONTENTS + YARN_INSTALL_DEPS + YARN_START,
            DOCKERIGNORE);
      });
+
+  it('should install the requested version of npm', async () => {
+    await runTest(
+        {
+          canInstallDeps: true,
+          npmVersion: NPM_VERSION,
+          nodeVersion: NODE_VERSION,
+          useYarn: true
+        },
+        BASE + UPGRADE_NODE + INSTALL_NPM + COPY_CONTENTS + YARN_INSTALL_DEPS +
+            YARN_START,
+        DOCKERIGNORE);
+  });
 });


### PR DESCRIPTION
**DO NOT LAND YET**. This should land after the beta runtime builder becomes the default.

If the package.json specifies an engines.npm field, fetch and install that version of npm.