### PR TITLE
The `GAE_APPLICATION_YAML_PATH` var is respected

### DIFF
--- a/base/package.json
+++ b/base/package.json
@@ -8,7 +8,7 @@
     "@types/mocha": "^2.2.41",
     "@types/node": "^7.0.18",
     "@types/node-uuid": "0.0.28",
-    "@types/request": "0.0.43",
+    "@types/request": "0.0.45",
     "clang-format": "^1.0.50",
     "del": "^2.2.2",
     "gulp": "^3.9.1",

--- a/builder/steps/gen-dockerfile/contents/data/dockerignore
+++ b/builder/steps/gen-dockerfile/contents/data/dockerignore
@@ -20,3 +20,4 @@ yarn-error.log
 .git
 .hg
 .svn
+<%- config.appYamlPath %>

--- a/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
+++ b/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
@@ -25,7 +25,7 @@ import * as yaml from 'js-yaml';
 import {Locator, Reader} from './fsview';
 import {Logger} from './logger';
 
-const APP_YAML = 'app.yaml';
+const DEFAULT_APP_YAML = 'app.yaml';
 const PACKAGE_JSON = './package.json';
 const YARN_LOCK = 'yarn.lock';
 
@@ -79,10 +79,13 @@ export interface Setup {
  */
 export async function detectSetup(
     logger: Logger, fsview: Reader&Locator): Promise<Setup> {
-  if (!(await fsview.exists(APP_YAML))) {
-    throw new Error(`The file ${APP_YAML} does not exist`);
+  const appYamlPath = process.env.GAE_APPLICATION_YAML_PATH ?
+      process.env.GAE_APPLICATION_YAML_PATH :
+      DEFAULT_APP_YAML;
+  if (!(await fsview.exists(appYamlPath))) {
+    throw new Error(`The file ${appYamlPath} does not exist`);
   }
-  const config = yaml.safeLoad(await fsview.read(APP_YAML));
+  const config = yaml.safeLoad(await fsview.read(appYamlPath));
 
   // If nodejs has been explicitly specified then treat warnings as errors.
   const warn: (m: string) => void =

--- a/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
+++ b/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
@@ -49,6 +49,11 @@ export interface Setup {
    * dependencies and launch the app.
    */
   useYarn: boolean;
+  /**
+   * Specifies the path relative to the application's root directory that
+   * identifies the app.yaml file used to deploy the application.
+   */
+  appYamlPath: string;
 }
 
 /**
@@ -160,11 +165,17 @@ export async function detectSetup(
         'the "server.js" file were found.');
   }
 
-  // extend filters undefined properties.
-  const setup = extend({}, {
+  // This variable is defined here to allow the Typescript compiler
+  // to properly verify it is of type `Setup`.  If its value is directly
+  // passed to the `extend` function, the compiler cannot check
+  // that the input is of type `Setup` since `extend` takes `Object`s.
+  const setup: Setup = {
     canInstallDeps: canInstallDeps,
     nodeVersion: nodeVersion ? shellEscape([nodeVersion]) : undefined,
-    useYarn: useYarn
-  });
-  return setup;
+    useYarn: useYarn,
+    appYamlPath: appYamlPath
+  };
+
+  // extend filters out undefined properties.
+  return extend({}, setup);
 }

--- a/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
+++ b/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
@@ -51,7 +51,7 @@ export interface Setup {
   useYarn: boolean;
   /**
    * Specifies the path relative to the application's root directory that
-   * identifies the app.yaml file used to deploy the application.
+   * identifies the yaml file used to deploy the application.
    */
   appYamlPath: string;
 }
@@ -69,8 +69,8 @@ export interface Setup {
  * @param fsview Represents a view of the root directory of a Node.js
  *               application.
  *
- * @throws If an `app.yaml` file does not exist in the directory desribed by
- *         the given {@link Locator}.
+ * @throws If the deployment yaml file does not exist in the directory desribed
+ *         by the given {@link Locator}.
  * @throws If a `package.json` file exists but a problem occurred while
  *         trying to parse the file.
  * @throws If the directory described by the {@link Reader} and {@link Locator}
@@ -84,9 +84,7 @@ export interface Setup {
  */
 export async function detectSetup(
     logger: Logger, fsview: Reader&Locator): Promise<Setup> {
-  const appYamlPath = process.env.GAE_APPLICATION_YAML_PATH ?
-      process.env.GAE_APPLICATION_YAML_PATH :
-      DEFAULT_APP_YAML;
+  const appYamlPath = process.env.GAE_APPLICATION_YAML_PATH || DEFAULT_APP_YAML;
   if (!(await fsview.exists(appYamlPath))) {
     throw new Error(`The file ${appYamlPath} does not exist`);
   }
@@ -113,7 +111,8 @@ export async function detectSetup(
     canInstallDeps = true;
 
     // Consider the yarn.lock file as present if and only if the yarn.lock
-    // file exists and is not specified as being skipped in app.yaml.
+    // file exists and is not specified as being skipped in the deploment yaml
+    // file.
     let skipFiles = config.skip_files || [];
     if (!Array.isArray(skipFiles)) {
       skipFiles = [skipFiles];

--- a/builder/steps/gen-dockerfile/contents/src/generate_files.ts
+++ b/builder/steps/gen-dockerfile/contents/src/generate_files.ts
@@ -21,6 +21,19 @@ import {Setup} from './detect_setup';
 import {FsView, Writer} from './fsview';
 
 /**
+ * Returns a string template with the specified template values filled in.
+ * Any blank lines are removed from the resulting string.
+ *
+ * @param template The template to render.
+ * @param data An object whose keys are used to identify the text in the
+ *  template to replace with the value of the object's key.
+ * @return The template supplied with the supplied data filled in.
+ */
+function renderTemplate(template: string, data?: ejs.Data): string {
+  return ejs.render(template, data).replace(/^\s*\n/gm, '');
+}
+
+/**
  * Generates a single file and records that the file was generated as well as
  * the contents of the file.
  *
@@ -65,14 +78,14 @@ export async function generateFiles(
 
   // Generate the Dockerfile and remove any empty lines
   const dockerfileTemplate = await dataDirReader.read('Dockerfile.txt');
-  const dockerfile = ejs.render(dockerfileTemplate, {
-                          baseImage: baseImage,
-                          tool: config.useYarn ? 'yarn' : 'npm',
-                          config: config
-                        })
-                         .replace(/^\s*\n/gm, '');
+  const dockerfile = renderTemplate(dockerfileTemplate, {
+    baseImage: baseImage,
+    tool: config.useYarn ? 'yarn' : 'npm',
+    config: config
+  });
 
-  const dockerignore = await dataDirReader.read('dockerignore');
+  const dockerignoreTemplate = await dataDirReader.read('dockerignore');
+  const dockerignore = renderTemplate(dockerignoreTemplate, {config: config});
 
   // Generate the Dockerfile and .dockerignore files
   await generateSingleFile(appDirWriter, genFiles, 'Dockerfile', dockerfile);

--- a/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
@@ -33,10 +33,12 @@ const VALID_APP_YAML_CONTENTS_SKIP_YARN =
 `;
 
 const INVALID_APP_YAML_CONTENTS = 'runtime: \'nodejs'
-    //         ^
-    //         +-- This is intentionally unclosed
+//         ^
+//         +-- This is intentionally unclosed
 
-    interface TestConfig {
+const DEFAULT_APP_YAML = 'app.yaml';
+
+interface TestConfig {
   title: string;
   locations: Location[];
   // This type is `Setup|undefined` instead of being optional because the
@@ -149,7 +151,11 @@ describe('detectSetup', () => {
       expectedLogs:
           ['Checking for Node.js.', 'node.js checker: No package.json file.'],
       expectedErrors: [],
-      expectedResult: {canInstallDeps: false, useYarn: false}
+      expectedResult: {
+        canInstallDeps: false,
+        useYarn: false,
+        appYamlPath: DEFAULT_APP_YAML
+      }
     });
 
     performTest({
@@ -168,7 +174,11 @@ describe('detectSetup', () => {
             'version, see ' +
             'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
       ],
-      expectedResult: {canInstallDeps: true, useYarn: false}
+      expectedResult: {
+        canInstallDeps: true,
+        useYarn: false,
+        appYamlPath: DEFAULT_APP_YAML
+      }
     });
 
     performTest({
@@ -192,7 +202,11 @@ describe('detectSetup', () => {
             'version, see ' +
             'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
       ],
-      expectedResult: {canInstallDeps: true, useYarn: false}
+      expectedResult: {
+        canInstallDeps: true,
+        useYarn: false,
+        appYamlPath: DEFAULT_APP_YAML
+      }
     });
 
     performTest({
@@ -211,7 +225,11 @@ describe('detectSetup', () => {
             'version, see ' +
             'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
       ],
-      expectedResult: {canInstallDeps: true, useYarn: true}
+      expectedResult: {
+        canInstallDeps: true,
+        useYarn: true,
+        appYamlPath: DEFAULT_APP_YAML
+      }
     });
 
     performTest({
@@ -233,7 +251,11 @@ describe('detectSetup', () => {
             'version, see ' +
             'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
       ],
-      expectedResult: {canInstallDeps: true, useYarn: false}
+      expectedResult: {
+        canInstallDeps: true,
+        useYarn: false,
+        appYamlPath: DEFAULT_APP_YAML
+      }
     });
 
     performTest({
@@ -261,7 +283,11 @@ describe('detectSetup', () => {
             'version, see ' +
             'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
       ],
-      expectedResult: {canInstallDeps: true, useYarn: false}
+      expectedResult: {
+        canInstallDeps: true,
+        useYarn: false,
+        appYamlPath: DEFAULT_APP_YAML
+      }
     });
 
     performTest({
@@ -283,7 +309,11 @@ describe('detectSetup', () => {
             'version, see ' +
             'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime'
       ],
-      expectedResult: {canInstallDeps: true, useYarn: true}
+      expectedResult: {
+        canInstallDeps: true,
+        useYarn: true,
+        appYamlPath: DEFAULT_APP_YAML
+      }
     });
 
     performTest({
@@ -299,7 +329,8 @@ describe('detectSetup', () => {
         {path: 'server.js', exists: true, contents: 'some content'},
         {path: 'yarn.lock', exists: true, contents: 'some content'}
       ],
-      expectedResult: {canInstallDeps: true, useYarn: true},
+      expectedResult:
+          {canInstallDeps: true, useYarn: true, appYamlPath: 'custom.yaml'},
       env: {GAE_APPLICATION_YAML_PATH: 'custom.yaml'}
     });
 
@@ -331,7 +362,11 @@ describe('detectSetup', () => {
         {path: 'server.js', exists: true, contents: 'some content'},
         {path: 'yarn.lock', exists: true, contents: 'some content'}
       ],
-      expectedResult: {canInstallDeps: true, useYarn: true}
+      expectedResult: {
+        canInstallDeps: true,
+        useYarn: true,
+        appYamlPath: DEFAULT_APP_YAML
+      }
     });
   });
 });

--- a/builder/steps/gen-dockerfile/contents/test/generate_files_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/generate_files_test.ts
@@ -17,7 +17,6 @@
 import * as assert from 'assert';
 
 import {Setup} from '../src/detect_setup';
-import {FsView} from '../src/fsview';
 import {generateFiles} from '../src/generate_files';
 
 import {Location, MockView} from './common';
@@ -67,53 +66,92 @@ const YARN_INSTALL_PRODUCTION_DEPS = `RUN yarn install --production || \\
 const YARN_START = `CMD yarn start\n`;
 const NPM_START = `CMD npm start\n`;
 
+const BASE_DOCKERIGNORE = `# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+node_modules
+.dockerignore
+Dockerfile
+npm-debug.log
+yarn-error.log
+.git
+.hg
+.svn`;
+
+const DEFAULT_APP_YAML = 'app.yaml';
+
+const DEFAULT_DOCKERIGNORE = `${BASE_DOCKERIGNORE}\n${DEFAULT_APP_YAML}\n`;
+
 interface TestConfig {
   config: Setup;
-  expectedDockerfile: string;
-  expectedDockerignore: string;
+  expectedDockerfile?: string;
+  expectedDockerignore?: string;
+}
+
+function hasLocation(locationArr: Location[], location: Location) {
+  return locationArr.findIndex(loc => {
+    return loc && loc.contents === location.contents &&
+        loc.exists === location.exists && loc.path === location.path;
+  }) !== -1;
 }
 
 async function runTest(testConfig: TestConfig) {
   const appView = new MockView([]);
   const files = await generateFiles(appView, testConfig.config, BASE_IMAGE);
   assert.ok(files);
+
+  // Verify the paths written matches the number of locations returned
+  // by the method.
   assert.strictEqual(files.size, 2);
+  assert.strictEqual(appView.pathsWritten.length, 2);
 
   assert.strictEqual(files.has(DOCKERFILE_NAME), true);
   assert.strictEqual(files.has(DOCKERIGNORE_NAME), true);
 
-  assert.strictEqual(files.get(DOCKERFILE_NAME), testConfig.expectedDockerfile);
-  assert.strictEqual(
-      files.get(DOCKERIGNORE_NAME), testConfig.expectedDockerignore);
+  if (testConfig.expectedDockerfile) {
+    assert.strictEqual(
+        files.get(DOCKERFILE_NAME), testConfig.expectedDockerfile);
+    assert(hasLocation(appView.pathsWritten, {
+      path: 'Dockerfile',
+      exists: true,
+      contents: testConfig.expectedDockerfile
+    }));
+  }
 
-  const expectedFilesWritten: Location[] = [
-    {path: 'Dockerfile', exists: true, contents: testConfig.expectedDockerfile},
-    {
+  if (testConfig.expectedDockerignore) {
+    assert.strictEqual(
+        files.get(DOCKERIGNORE_NAME), testConfig.expectedDockerignore);
+    assert(hasLocation(appView.pathsWritten, {
       path: '.dockerignore',
       exists: true,
       contents: testConfig.expectedDockerignore
-    }
-  ];
-
-  assert.strictEqual(appView.pathsWritten.length, 2);
-  assert.deepStrictEqual(appView.pathsWritten, expectedFilesWritten);
+    }));
+  }
 }
 
 describe('generateFiles', async () => {
-  let DOCKERIGNORE: string;
-  before(async () => {
-    const dataView = new FsView('.');
-    DOCKERIGNORE = await dataView.read('./data/dockerignore');
-  });
-
   it('should generate correctly without installing dependencies, without ' +
          'start script, without Node.version, and using npm',
      async () => {
        await runTest({
-         config:
-             {canInstallDeps: false, nodeVersion: undefined, useYarn: false},
+         config: {
+           canInstallDeps: false,
+           nodeVersion: undefined,
+           useYarn: false,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile: BASE + COPY_CONTENTS + NPM_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -121,9 +159,14 @@ describe('generateFiles', async () => {
          'start script, without Node.version, and using yarn',
      async () => {
        await runTest({
-         config: {canInstallDeps: false, nodeVersion: undefined, useYarn: true},
+         config: {
+           canInstallDeps: false,
+           nodeVersion: undefined,
+           useYarn: true,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile: BASE + COPY_CONTENTS + YARN_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -135,9 +178,10 @@ describe('generateFiles', async () => {
            canInstallDeps: false,
            nodeVersion: NODE_VERSION,
            useYarn: false,
+           appYamlPath: DEFAULT_APP_YAML
          },
          expectedDockerfile: BASE + UPGRADE_NODE + COPY_CONTENTS + NPM_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -145,10 +189,14 @@ describe('generateFiles', async () => {
          'start script, with Node.version, and using yarn',
      async () => {
        await runTest({
-         config:
-             {canInstallDeps: false, nodeVersion: NODE_VERSION, useYarn: true},
+         config: {
+           canInstallDeps: false,
+           nodeVersion: NODE_VERSION,
+           useYarn: true,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile: BASE + UPGRADE_NODE + COPY_CONTENTS + YARN_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -156,10 +204,14 @@ describe('generateFiles', async () => {
          'script, without Node.version, and using npm',
      async () => {
        await runTest({
-         config:
-             {canInstallDeps: false, nodeVersion: undefined, useYarn: false},
+         config: {
+           canInstallDeps: false,
+           nodeVersion: undefined,
+           useYarn: false,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile: BASE + COPY_CONTENTS + NPM_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -167,9 +219,14 @@ describe('generateFiles', async () => {
          'script, without Node.version, and using yarn',
      async () => {
        await runTest({
-         config: {canInstallDeps: false, nodeVersion: undefined, useYarn: true},
+         config: {
+           canInstallDeps: false,
+           nodeVersion: undefined,
+           useYarn: true,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile: BASE + COPY_CONTENTS + YARN_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -177,10 +234,14 @@ describe('generateFiles', async () => {
          'script, with Node.version, and using npm',
      async () => {
        await runTest({
-         config:
-             {canInstallDeps: false, nodeVersion: NODE_VERSION, useYarn: false},
+         config: {
+           canInstallDeps: false,
+           nodeVersion: NODE_VERSION,
+           useYarn: false,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile: BASE + UPGRADE_NODE + COPY_CONTENTS + NPM_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -188,10 +249,14 @@ describe('generateFiles', async () => {
          'script, with Node.version, and using yarn',
      async () => {
        await runTest({
-         config:
-             {canInstallDeps: false, nodeVersion: NODE_VERSION, useYarn: true},
+         config: {
+           canInstallDeps: false,
+           nodeVersion: NODE_VERSION,
+           useYarn: true,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile: BASE + UPGRADE_NODE + COPY_CONTENTS + YARN_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -199,10 +264,15 @@ describe('generateFiles', async () => {
          'script, without Node.version, and using npm',
      async () => {
        await runTest({
-         config: {canInstallDeps: true, nodeVersion: undefined, useYarn: false},
+         config: {
+           canInstallDeps: true,
+           nodeVersion: undefined,
+           useYarn: false,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile:
              BASE + COPY_CONTENTS + NPM_INSTALL_PRODUCTION_DEPS + NPM_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -210,10 +280,15 @@ describe('generateFiles', async () => {
          'script, without Node.version, and using yarn',
      async () => {
        await runTest({
-         config: {canInstallDeps: true, nodeVersion: undefined, useYarn: true},
+         config: {
+           canInstallDeps: true,
+           nodeVersion: undefined,
+           useYarn: true,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile:
              BASE + COPY_CONTENTS + YARN_INSTALL_PRODUCTION_DEPS + YARN_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -221,11 +296,15 @@ describe('generateFiles', async () => {
          'script, with Node.version, and using npm',
      async () => {
        await runTest({
-         config:
-             {canInstallDeps: true, nodeVersion: NODE_VERSION, useYarn: false},
+         config: {
+           canInstallDeps: true,
+           nodeVersion: NODE_VERSION,
+           useYarn: false,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile: BASE + UPGRADE_NODE + COPY_CONTENTS +
              NPM_INSTALL_PRODUCTION_DEPS + NPM_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -233,11 +312,15 @@ describe('generateFiles', async () => {
          'script, with Node.version, and using yarn',
      async () => {
        await runTest({
-         config:
-             {canInstallDeps: true, nodeVersion: NODE_VERSION, useYarn: true},
+         config: {
+           canInstallDeps: true,
+           nodeVersion: NODE_VERSION,
+           useYarn: true,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile: BASE + UPGRADE_NODE + COPY_CONTENTS +
              YARN_INSTALL_PRODUCTION_DEPS + YARN_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -245,10 +328,15 @@ describe('generateFiles', async () => {
          'script, without Node.version, and using npm',
      async () => {
        await runTest({
-         config: {canInstallDeps: true, nodeVersion: undefined, useYarn: false},
+         config: {
+           canInstallDeps: true,
+           nodeVersion: undefined,
+           useYarn: false,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile:
              BASE + COPY_CONTENTS + NPM_INSTALL_PRODUCTION_DEPS + NPM_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -256,10 +344,15 @@ describe('generateFiles', async () => {
          'script, without Node.version, and using yarn',
      async () => {
        await runTest({
-         config: {canInstallDeps: true, nodeVersion: undefined, useYarn: true},
+         config: {
+           canInstallDeps: true,
+           nodeVersion: undefined,
+           useYarn: true,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile:
              BASE + COPY_CONTENTS + YARN_INSTALL_PRODUCTION_DEPS + YARN_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -267,11 +360,15 @@ describe('generateFiles', async () => {
          'script, with Node.version, and using npm',
      async () => {
        await runTest({
-         config:
-             {canInstallDeps: true, nodeVersion: NODE_VERSION, useYarn: false},
+         config: {
+           canInstallDeps: true,
+           nodeVersion: NODE_VERSION,
+           useYarn: false,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile: BASE + UPGRADE_NODE + COPY_CONTENTS +
              NPM_INSTALL_PRODUCTION_DEPS + NPM_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
        });
      });
 
@@ -279,11 +376,29 @@ describe('generateFiles', async () => {
          'script, with Node.version, and using yarn',
      async () => {
        await runTest({
-         config:
-             {canInstallDeps: true, nodeVersion: NODE_VERSION, useYarn: true},
+         config: {
+           canInstallDeps: true,
+           nodeVersion: NODE_VERSION,
+           useYarn: true,
+           appYamlPath: DEFAULT_APP_YAML
+         },
          expectedDockerfile: BASE + UPGRADE_NODE + COPY_CONTENTS +
              YARN_INSTALL_PRODUCTION_DEPS + YARN_START,
-         expectedDockerignore: DOCKERIGNORE
+         expectedDockerignore: DEFAULT_DOCKERIGNORE
+       });
+     });
+
+  it('should generate a .dockerignore file with a custom app.yaml path if ' +
+         'specified',
+     async () => {
+       await runTest({
+         config: {
+           canInstallDeps: true,
+           nodeVersion: NODE_VERSION,
+           useYarn: true,
+           appYamlPath: 'custom.yaml'
+         },
+         expectedDockerignore: `${BASE_DOCKERIGNORE}\ncustom.yaml\n`
        });
      });
 });

--- a/builder/steps/gen-dockerfile/contents/test/generate_files_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/generate_files_test.ts
@@ -388,8 +388,8 @@ describe('generateFiles', async () => {
        });
      });
 
-  it('should generate a .dockerignore file with a custom app.yaml path if ' +
-         'specified',
+  it('should generate a .dockerignore file with a custom deployment yaml ' +
+         'path if specified',
      async () => {
        await runTest({
          config: {


### PR DESCRIPTION
Now if the `GAE_APPLICATION_YAML_PATH` environment variable is defined, its value will be used as the path to the application's `app.yaml` file.  Otherwise, if it is not defined, a default value of `app.yaml` will be used.