### PR TITLE
Verification output is only printed on error

### DIFF
--- a/runtime-image/contents/verify_node
+++ b/runtime-image/contents/verify_node
@@ -59,7 +59,7 @@ set +e
 output=$(gpg --no-default-keyring --keyring ${keys_gpg_file} --verify ${shasums_file} 2>&1)
 exit_code=$?
 if [[ $exit_code != 0 ]]; then
-  echo ${output}
+  echo ${output} >&2
   cleanUp
   exit $exit_code
 fi

--- a/runtime-image/contents/verify_node
+++ b/runtime-image/contents/verify_node
@@ -55,8 +55,15 @@ function cleanUp {
 # in the default keyring are *not* used.  Otherwise, a key already existing in
 # the default keyring could verify the file, but no keys in the KEYS file
 # verify the file, which would incorrectly report that the file is verified.
-(gpg --no-default-keyring --keyring ${keys_gpg_file} --verify ${shasums_file}) \
-  || (cleanUp; exit 1)
+set +e
+output=$(gpg --no-default-keyring --keyring ${keys_gpg_file} --verify ${shasums_file} 2>&1)
+exit_code=$?
+if [[ $exit_code != 0 ]]; then
+  echo ${output}
+  cleanUp
+  exit $exit_code
+fi
+set -e
 
 # Verify the Node.js binary
 (grep ${nodejs_file} ${shasums_file} | shasum --algorithm 256 -c -) \

--- a/runtime-image/test/test_config.yaml
+++ b/runtime-image/test/test_config.yaml
@@ -23,6 +23,11 @@ commandTests:
   command: ['install_node', 'v5.9.0']
   excludedOutput: ['node-v5.9.0-linux-x64/.*']
 
+- name: 'Trusted Keys Do Not Cause Warnings'
+  teardown: [['install_node', 'v6.11.1']]
+  command: ['install_node', 'v5.9.0']
+  excludedOutput: ['gpg: WARNING: This key is not certified with a trusted signature!']
+
 - name: 'Yarn Executable'
   command: ['bash', '-c', 'yarn &> /dev/null && echo "ran without errors"']
   expectedOutput: ['ran without errors\n']

--- a/runtime-image/test/test_config.yaml
+++ b/runtime-image/test/test_config.yaml
@@ -29,6 +29,26 @@ commandTests:
   excludedOutput: ['gpg: WARNING: This key is not certified with a trusted signature!']
   excludedError: ['gpg: WARNING: This key is not certified with a trusted signature!']
 
+- name: 'Node Verification Errors are Displayed'
+  setup: [['mkdir', '/tmp/node_verification_failure_test_dir'],
+          ['curl', '-o',
+           '/tmp/node_verification_failure_test_dir/SHASUMS256.txt.asc',
+           'https://nodejs.org/dist/v6.11.1/SHASUMS256.txt.asc'],
+          ['curl', '-o',
+           '/tmp/node_verification_failure_test_dir/node-v6.11.1-linux-x86.tar.gz',
+           'https://nodejs.org/dist/v6.11.1/node-v6.11.1-linux-x86.tar.gz'],
+          ['sed', '-i',
+           's/iQEcBAEBCA/xxxxxxxxxx/g',
+           '/tmp/node_verification_failure_test_dir/SHASUMS256.txt.asc']]
+  command: ['/opt/gcp/runtime/verify_node',
+            '/tmp/node_verification_failure_test_dir/node-v6.11.1-linux-x86.tar.gz',
+            '/tmp/node_verification_failure_test_dir/SHASUMS256.txt.asc']
+  teardown: [['rm', '/tmp/node_verification_failure_test_dir/SHASUMS256.txt.asc'],
+             ['rm', '/tmp/node_verification_failure_test_dir/node-v6.11.1-linux-x86.tar.gz'],
+             ['rmdir', '/tmp/node_verification_failure_test_dir']]
+  expectedError: ['the signature could not be verified.']
+  exitCode: 2
+
 - name: 'Yarn Executable'
   command: ['bash', '-c', 'yarn &> /dev/null && echo "ran without errors"']
   expectedOutput: ['ran without errors\n']

--- a/runtime-image/test/test_config.yaml
+++ b/runtime-image/test/test_config.yaml
@@ -27,6 +27,7 @@ commandTests:
   teardown: [['install_node', 'v6.11.1']]
   command: ['install_node', 'v5.9.0']
   excludedOutput: ['gpg: WARNING: This key is not certified with a trusted signature!']
+  excludedError: ['gpg: WARNING: This key is not certified with a trusted signature!']
 
 - name: 'Yarn Executable'
   command: ['bash', '-c', 'yarn &> /dev/null && echo "ran without errors"']


### PR DESCRIPTION
If Node.js binary verification fails, the output associated with
the verification process is printed to standard out.  Otherwise,
nothing is printed.