### PR TITLE
Remove extra quotes around a Node version

### DIFF
--- a/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
+++ b/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
@@ -164,13 +164,19 @@ export async function detectSetup(
         'the "server.js" file were found.');
   }
 
+  if (nodeVersion) {
+    nodeVersion = shellEscape([nodeVersion.trim()])
+                      .replace(/^'+/g, '')
+                      .replace(/'+$/g, '');
+  }
+
   // This variable is defined here to allow the Typescript compiler
   // to properly verify it is of type `Setup`.  If its value is directly
   // passed to the `extend` function, the compiler cannot check
   // that the input is of type `Setup` since `extend` takes `Object`s.
   const setup: Setup = {
     canInstallDeps: canInstallDeps,
-    nodeVersion: nodeVersion ? shellEscape([nodeVersion]) : undefined,
+    nodeVersion: nodeVersion,
     useYarn: useYarn,
     appYamlPath: appYamlPath
   };

--- a/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
@@ -369,4 +369,24 @@ describe('detectSetup', () => {
       }
     });
   });
+
+  performTest({
+    title: 'should properly detect a Node version specification',
+    locations: [
+      {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS}, {
+        path: 'package.json',
+        exists: true,
+        contents:
+            JSON.stringify({name: 'some-package', engines: {node: '>=4.3.2'}})
+      },
+      {path: 'server.js', exists: true, contents: 'some content'},
+      {path: 'yarn.lock', exists: false}
+    ],
+    expectedResult: {
+      canInstallDeps: true,
+      useYarn: false,
+      appYamlPath: DEFAULT_APP_YAML,
+      nodeVersion: '>=4.3.2'
+    }
+  });
 });


### PR DESCRIPTION
If a node version is specified in the engines field of the
`package.json` file, the generated Dockerfile now will contain
a line:
```
   RUN install_node '<version>'
```
Before this commit, the line would have been:
```
   RUN install_node ''<version>''
```
and included extra single quotes.