### PR TITLE
Handle `yarn.lock` and `package-lock.json`

### DIFF
--- a/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
+++ b/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
@@ -138,7 +138,7 @@ export async function detectSetup(
 
   function isSkipped(filename: string): boolean {
     return skipFiles.some(
-        (pattern: string) => new RegExp(pattern).test(filename));
+        (pattern: string) => {new RegExp(pattern).test(filename)});
   }
 
   const yarnLockExists: boolean =

--- a/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
+++ b/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
@@ -29,11 +29,12 @@ const DEFAULT_APP_YAML = 'app.yaml';
 const PACKAGE_JSON = './package.json';
 const YARN_LOCK = 'yarn.lock';
 const PACKAGE_LOCK_JSON = 'package-lock.json';
-const CANNOT_RESOLVE_PACKAGE_MANAGER = 'The presence of yarn.lock ' +
-    'indicates that yarn should be used, but the presence of ' +
-    'package-lock.json indicates npm should be used.  Use the skip_files ' +
-    'section of app.yaml to ignore the appropriate file to indicate ' +
-    'which package manager to use.';
+const CANNOT_RESOLVE_PACKAGE_MANAGER = 'Cannot determine which package ' +
+    'manager to use as both yarn.lock and package-lock.json files ' +
+    'were detected.  The presence of yarn.lock indicates that yarn should be ' +
+    'used, but the presence of package-lock.json indicates npm should be ' +
+    'used.  Use the skip_files section of app.yaml to ignore the appropriate ' +
+    'file to indicate which package manager to use.';
 
 /**
  * Encapsulates the information about the Node.js application detected by
@@ -138,7 +139,7 @@ export async function detectSetup(
 
   function isSkipped(filename: string): boolean {
     return skipFiles.some(
-        (pattern: string) => {new RegExp(pattern).test(filename)});
+        (pattern: string) => {return new RegExp(pattern).test(filename)});
   }
 
   const yarnLockExists: boolean =

--- a/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
+++ b/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
@@ -28,6 +28,12 @@ import {Logger} from './logger';
 const DEFAULT_APP_YAML = 'app.yaml';
 const PACKAGE_JSON = './package.json';
 const YARN_LOCK = 'yarn.lock';
+const PACKAGE_LOCK_JSON = 'package-lock.json';
+const CANNOT_RESOLVE_PACKAGE_MANAGER = 'The presence of yarn.lock ' +
+    'indicates that yarn should be used, but the presence of ' +
+    'package-lock.json indicates npm should be used.  Use the skip_files ' +
+    'section of app.yaml to ignore the appropriate file to indicate ' +
+    'which package manager to use.';
 
 /**
  * Encapsulates the information about the Node.js application detected by
@@ -123,34 +129,39 @@ export async function detectSetup(
 
   logger.log('Checking for Node.js.');
 
+  // Consider a file as present if and only if the file exists and is not
+  // specified as being skipped in the deploment yaml file.
+  let skipFiles = config.skip_files || [];
+  if (!Array.isArray(skipFiles)) {
+    skipFiles = [skipFiles];
+  }
+
+  function isSkipped(filename: string): boolean {
+    return skipFiles.some(
+        (pattern: string) => new RegExp(pattern).test(filename));
+  }
+
+  const yarnLockExists: boolean =
+      !isSkipped(YARN_LOCK) && await fsview.exists(YARN_LOCK);
+  const packageLockExists: boolean =
+      !isSkipped(PACKAGE_LOCK_JSON) && await fsview.exists(PACKAGE_LOCK_JSON);
+  if (yarnLockExists && packageLockExists) {
+    throw new Error(CANNOT_RESOLVE_PACKAGE_MANAGER);
+  }
+
   let canInstallDeps: boolean;
   let gotScriptsStart: boolean;
   let npmVersion: string|undefined;
   let yarnVersion: string|undefined;
   let nodeVersion: string|undefined;
-  let useYarn: boolean;
 
   if (!(await fsview.exists(PACKAGE_JSON))) {
     logger.log('node.js checker: No package.json file.');
     canInstallDeps = false;
     gotScriptsStart = false;
     nodeVersion = undefined;
-    useYarn = false;
   } else {
     canInstallDeps = true;
-
-    // Consider the yarn.lock file as present if and only if the yarn.lock
-    // file exists and is not specified as being skipped in the deploment yaml
-    // file.
-    let skipFiles = config.skip_files || [];
-    if (!Array.isArray(skipFiles)) {
-      skipFiles = [skipFiles];
-    }
-
-    const yarnLockExists: boolean = await fsview.exists(YARN_LOCK);
-    const yarnLockSkipped = skipFiles.some(
-        (pattern: string) => new RegExp(pattern).test(YARN_LOCK));
-    useYarn = yarnLockExists && !yarnLockSkipped;
 
     // Try to read the package.json file.
     let packageJson;
@@ -200,7 +211,7 @@ export async function detectSetup(
     npmVersion: escape(npmVersion),
     yarnVersion: escape(yarnVersion),
     nodeVersion: escape(nodeVersion),
-    useYarn: useYarn,
+    useYarn: yarnLockExists,
     appYamlPath: appYamlPath
   };
 

--- a/builder/steps/gen-dockerfile/contents/test/common.ts
+++ b/builder/steps/gen-dockerfile/contents/test/common.ts
@@ -37,11 +37,26 @@ export interface Location {
 }
 
 export class MockView implements Reader, Writer, Locator {
+  readonly configs: ReadonlyArray<Location>;
   readonly pathsRead: Location[] = [];
   readonly pathsLocated: Location[] = [];
   readonly pathsWritten: Location[] = [];
 
-  constructor(private configs: ReadonlyArray<Location>) {}
+  constructor(configurations: ReadonlyArray<Location>) {
+    const paths = new Set<string>();
+    const uniqueConfigs: Location[] = [];
+    for (let conf of configurations) {
+      if (paths.has(conf.path)) {
+        throw new Error(
+            `Cannot specify the same path twice: ${
+                                                   JSON.stringify(conf, null, 2)
+                                                 }`);
+      }
+      paths.add(conf.path);
+      uniqueConfigs.push(conf);
+    }
+    this.configs = uniqueConfigs;
+  }
 
   private findLocation(path: string): Location|undefined {
     const resolvedPath = path.replace(/\.\//g, '');

--- a/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
@@ -574,7 +574,7 @@ describe('detectSetup', () => {
   describe('should detect the correct package manager', () => {
     performTest({
       title: 'should detect npm if neither yarn.lock nor ' +
-          'package-lock.json exist',
+          'package-lock.json exist and package.json exists',
       locations: [
         {path: 'package.json', exists: true, contents: '{}'},
         {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
@@ -590,8 +590,25 @@ describe('detectSetup', () => {
     });
 
     performTest({
+      title: 'should detect npm if neither yarn.lock nor ' +
+          'package-lock.json exist and package.json does not exist',
+      locations: [
+        {path: 'package.json', exists: false},
+        {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
+        {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
+        {path: 'yarn.lock', exists: false},
+        {path: 'package-lock.json', exists: false}
+      ],
+      expectedResult: {
+        canInstallDeps: false,
+        appYamlPath: DEFAULT_APP_YAML,
+        useYarn: false
+      }
+    });
+
+    performTest({
       title: 'should detect npm if yarn.lock does not exist and ' +
-          'package-lock.json exists',
+          'package-lock.json exists and package.json exists',
       locations: [
         {path: 'package.json', exists: true, contents: '{}'},
         {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
@@ -607,8 +624,25 @@ describe('detectSetup', () => {
     });
 
     performTest({
+      title: 'should detect npm if yarn.lock does not exist and ' +
+          'package-lock.json exists and package.json does not exist',
+      locations: [
+        {path: 'package.json', exists: false},
+        {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
+        {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
+        {path: 'yarn.lock', exists: false},
+        {path: 'package-lock.json', exists: true}
+      ],
+      expectedResult: {
+        canInstallDeps: false,
+        appYamlPath: DEFAULT_APP_YAML,
+        useYarn: false
+      }
+    });
+
+    performTest({
       title: 'should detect yarn if yarn.lock exists and ' +
-          'package-lock.json does not exist',
+          'package-lock.json does not exist and package.json exists',
       locations: [
         {path: 'package.json', exists: true, contents: '{}'},
         {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
@@ -624,10 +658,46 @@ describe('detectSetup', () => {
     });
 
     performTest({
+      title: 'should detect yarn if yarn.lock exists and ' +
+          'package-lock.json does not exist and package.json does not exist',
+      locations: [
+        {path: 'package.json', exists: false},
+        {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
+        {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
+        {path: 'yarn.lock', exists: true},
+        {path: 'package-lock.json', exists: false}
+      ],
+      expectedResult: {
+        canInstallDeps: false,
+        appYamlPath: DEFAULT_APP_YAML,
+        useYarn: true
+      }
+    });
+
+    performTest({
       title: 'should throw an error if both yarn.lock and ' +
-          'package-lock.json exist',
+          'package-lock.json exist and package.json exists',
       locations: [
         {path: 'package.json', exists: true, contents: '{}'},
+        {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
+        {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
+        {path: 'yarn.lock', exists: true},
+        {path: 'package-lock.json', exists: true}
+      ],
+      expectedResult: undefined,
+      expectedThrownErrMessage: new RegExp(
+          'The presence of yarn.lock ' +
+          'indicates that yarn should be used, but the presence of ' +
+          'package-lock.json indicates npm should be used.  Use the skip_files ' +
+          'section of app.yaml to ignore the appropriate file to indicate ' +
+          'which package manager to use.')
+    });
+
+    performTest({
+      title: 'should throw an error if both yarn.lock and ' +
+          'package-lock.json exist and package.json does not exist',
+      locations: [
+        {path: 'package.json', exists: false},
         {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
         {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
         {path: 'yarn.lock', exists: true},

--- a/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
@@ -705,11 +705,12 @@ describe('detectSetup', () => {
       ],
       expectedResult: undefined,
       expectedThrownErrMessage: new RegExp(
-          'The presence of yarn.lock ' +
-          'indicates that yarn should be used, but the presence of ' +
-          'package-lock.json indicates npm should be used.  Use the skip_files ' +
-          'section of app.yaml to ignore the appropriate file to indicate ' +
-          'which package manager to use.')
+          '^Cannot determine which package manager to use as both yarn.lock ' +
+          'and package-lock.json files were detected.  The presence of ' +
+          'yarn.lock indicates that yarn should be used, but the presence ' +
+          'of package-lock.json indicates npm should be used.  Use the ' +
+          'skip_files section of app.yaml to ignore the appropriate file ' +
+          'to indicate which package manager to use.$')
     });
   });
 });

--- a/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
@@ -38,6 +38,8 @@ const INVALID_APP_YAML_CONTENTS = 'runtime: \'nodejs'
 
 const DEFAULT_APP_YAML = 'app.yaml';
 
+const SERVER_JS_CONTENTS = 'echo(\'Hello world\')';
+
 interface TestConfig {
   title: string;
   locations: Location[];
@@ -127,7 +129,8 @@ describe('detectSetup', () => {
       locations: [
         {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
         {path: 'package.json', exists: false},
-        {path: 'server.js', exists: false}
+        {path: 'server.js', exists: false}, {path: 'yarn.lock', exists: false},
+        {path: 'package-lock.json', exists: false}
       ],
       expectedLogs:
           ['Checking for Node.js.', 'node.js checker: No package.json file.'],
@@ -147,7 +150,9 @@ describe('detectSetup', () => {
           locations: [
             {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
             {path: 'package.json', exists: false},
-            {path: 'server.js', exists: true, contents: 'some content'}
+            {path: 'server.js', exists: true, contents: 'some content'},
+            {path: 'yarn.lock', exists: false},
+            {path: 'package-lock.json', exists: false}
           ],
           expectedLogs: [
             'Checking for Node.js.', 'node.js checker: No package.json file.'
@@ -168,7 +173,8 @@ describe('detectSetup', () => {
             {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
             {path: 'package.json', exists: true, contents: '{}'},
             {path: 'server.js', exists: true, contents: 'some content'},
-            {path: 'yarn.lock', exists: false}
+            {path: 'yarn.lock', exists: false},
+            {path: 'package-lock.json', exists: false}
           ],
           expectedLogs: ['Checking for Node.js.'],
           expectedErrors: [
@@ -195,7 +201,8 @@ describe('detectSetup', () => {
             },
             {path: 'package.json', exists: true, contents: '{}'},
             {path: 'server.js', exists: true, contents: 'some content'},
-            {path: 'yarn.lock', exists: true, contents: 'some contents'}
+            {path: 'yarn.lock', exists: true, contents: 'some contents'},
+            {path: 'package-lock.json', exists: false}
           ],
           expectedLogs: ['Checking for Node.js.'],
           expectedErrors: [
@@ -217,7 +224,8 @@ describe('detectSetup', () => {
             {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
             {path: 'package.json', exists: true, contents: '{}'},
             {path: 'server.js', exists: true, contents: 'some content'},
-            {path: 'yarn.lock', exists: true, contents: 'some content'}
+            {path: 'yarn.lock', exists: true, contents: 'some content'},
+            {path: 'package-lock.json', exists: false}
           ],
           expectedLogs: ['Checking for Node.js.'],
           expectedErrors: [
@@ -243,7 +251,8 @@ describe('detectSetup', () => {
               contents: JSON.stringify({scripts: {start: 'npm start'}})
             },
             {path: 'server.js', exists: true, contents: 'some content'},
-            {path: 'yarn.lock', exists: false}
+            {path: 'yarn.lock', exists: false},
+            {path: 'package-lock.json', exists: false}
           ],
           expectedLogs: ['Checking for Node.js.'],
           expectedErrors: [
@@ -274,7 +283,8 @@ describe('detectSetup', () => {
               contents: JSON.stringify({scripts: {start: 'npm start'}})
             },
             {path: 'server.js', exists: true, contents: 'some content'},
-            {path: 'yarn.lock', exists: true, contents: 'some contents'}
+            {path: 'yarn.lock', exists: true, contents: 'some contents'},
+            {path: 'package-lock.json', exists: false}
           ],
           expectedLogs: ['Checking for Node.js.'],
           expectedErrors: [
@@ -301,7 +311,8 @@ describe('detectSetup', () => {
               contents: JSON.stringify({scripts: {start: 'npm start'}})
             },
             {path: 'server.js', exists: true, contents: 'some content'},
-            {path: 'yarn.lock', exists: true, contents: 'some content'}
+            {path: 'yarn.lock', exists: true, contents: 'some content'},
+            {path: 'package-lock.json', exists: false}
           ],
           expectedLogs: ['Checking for Node.js.'],
           expectedErrors: [
@@ -329,7 +340,8 @@ describe('detectSetup', () => {
           contents: JSON.stringify({scripts: {start: 'npm start'}})
         },
         {path: 'server.js', exists: true, contents: 'some content'},
-        {path: 'yarn.lock', exists: true, contents: 'some content'}
+        {path: 'yarn.lock', exists: true, contents: 'some content'},
+        {path: 'package-lock.json', exists: false}
       ],
       expectedResult:
           {canInstallDeps: true, useYarn: true, appYamlPath: 'custom.yaml'},
@@ -362,7 +374,8 @@ describe('detectSetup', () => {
           contents: JSON.stringify({scripts: {start: 'npm start'}})
         },
         {path: 'server.js', exists: true, contents: 'some content'},
-        {path: 'yarn.lock', exists: true, contents: 'some content'}
+        {path: 'yarn.lock', exists: true, contents: 'some content'},
+        {path: 'package-lock.json', exists: false}
       ],
       expectedResult: {
         canInstallDeps: true,
@@ -383,7 +396,8 @@ describe('detectSetup', () => {
               {name: 'some-package', engines: {node: '>=4.3.2'}})
         },
         {path: 'server.js', exists: true, contents: 'some content'},
-        {path: 'yarn.lock', exists: false}
+        {path: 'yarn.lock', exists: false},
+        {path: 'package-lock.json', exists: false}
       ],
       expectedResult: {
         canInstallDeps: true,
@@ -404,7 +418,8 @@ describe('detectSetup', () => {
           contents: JSON.stringify({name: 'some-package'})
         },
         {path: 'server.js', exists: true, contents: 'some content'},
-        {path: 'yarn.lock', exists: false}
+        {path: 'yarn.lock', exists: false},
+        {path: 'package-lock.json', exists: false}
       ],
       expectedResult: {
         canInstallDeps: true,
@@ -426,7 +441,8 @@ describe('detectSetup', () => {
               {engines: {yarn: '5.x'}, scripts: {start: 'npm start'}})
         },
         {path: 'app.yaml', exists: true, contents: 'some contents'},
-        {path: 'yarn.lock', exists: false}
+        {path: 'yarn.lock', exists: false},
+        {path: 'package-lock.json', exists: false}
       ],
       expectedResult: {
         canInstallDeps: true,
@@ -447,7 +463,8 @@ describe('detectSetup', () => {
           contents: JSON.stringify({scripts: {start: 'npm start'}})
         },
         {path: 'app.yaml', exists: true, contents: 'some contents'},
-        {path: 'yarn.lock', exists: false}
+        {path: 'yarn.lock', exists: false},
+        {path: 'package-lock.json', exists: false}
       ],
       expectedResult: {
         canInstallDeps: true,
@@ -469,7 +486,8 @@ describe('detectSetup', () => {
               {engines: {npm: '5.x'}, scripts: {start: 'npm start'}})
         },
         {path: 'app.yaml', exists: true, contents: 'some contents'},
-        {path: 'yarn.lock', exists: false}
+        {path: 'yarn.lock', exists: false},
+        {path: 'package-lock.json', exists: false}
       ],
       expectedResult: {
         canInstallDeps: true,
@@ -489,7 +507,8 @@ describe('detectSetup', () => {
           contents: JSON.stringify({scripts: {start: 'npm start'}})
         },
         {path: 'app.yaml', exists: true, contents: 'some contents'},
-        {path: 'yarn.lock', exists: false}
+        {path: 'yarn.lock', exists: false},
+        {path: 'package-lock.json', exists: false}
       ],
       expectedResult: {
         canInstallDeps: true,
@@ -514,7 +533,8 @@ describe('detectSetup', () => {
           })
         },
         {path: 'app.yaml', exists: true, contents: 'some contents'},
-        {path: 'yarn.lock', exists: false}
+        {path: 'yarn.lock', exists: false},
+        {path: 'package-lock.json', exists: false}
       ],
       expectedResult: {
         canInstallDeps: true,
@@ -538,7 +558,8 @@ describe('detectSetup', () => {
           })
         },
         {path: 'app.yaml', exists: true, contents: 'some contents'},
-        {path: 'yarn.lock', exists: true}
+        {path: 'yarn.lock', exists: true},
+        {path: 'package-lock.json', exists: false}
       ],
       expectedResult: {
         canInstallDeps: true,
@@ -547,6 +568,78 @@ describe('detectSetup', () => {
         appYamlPath: DEFAULT_APP_YAML,
         useYarn: true
       }
+    });
+  });
+
+  describe('should detect the correct package manager', () => {
+    performTest({
+      title: 'should detect npm if neither yarn.lock nor ' +
+          'package-lock.json exist',
+      locations: [
+        {path: 'package.json', exists: true, contents: '{}'},
+        {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
+        {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
+        {path: 'yarn.lock', exists: false},
+        {path: 'package-lock.json', exists: false}
+      ],
+      expectedResult: {
+        canInstallDeps: true,
+        appYamlPath: DEFAULT_APP_YAML,
+        useYarn: false
+      }
+    });
+
+    performTest({
+      title: 'should detect npm if yarn.lock does not exist and ' +
+          'package-lock.json exists',
+      locations: [
+        {path: 'package.json', exists: true, contents: '{}'},
+        {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
+        {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
+        {path: 'yarn.lock', exists: false},
+        {path: 'package-lock.json', exists: true}
+      ],
+      expectedResult: {
+        canInstallDeps: true,
+        appYamlPath: DEFAULT_APP_YAML,
+        useYarn: false
+      }
+    });
+
+    performTest({
+      title: 'should detect yarn if yarn.lock exists and ' +
+          'package-lock.json does not exist',
+      locations: [
+        {path: 'package.json', exists: true, contents: '{}'},
+        {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
+        {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
+        {path: 'yarn.lock', exists: true},
+        {path: 'package-lock.json', exists: false}
+      ],
+      expectedResult: {
+        canInstallDeps: true,
+        appYamlPath: DEFAULT_APP_YAML,
+        useYarn: true
+      }
+    });
+
+    performTest({
+      title: 'should throw an error if both yarn.lock and ' +
+          'package-lock.json exist',
+      locations: [
+        {path: 'package.json', exists: true, contents: '{}'},
+        {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
+        {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
+        {path: 'yarn.lock', exists: true},
+        {path: 'package-lock.json', exists: true}
+      ],
+      expectedResult: undefined,
+      expectedThrownErrMessage: new RegExp(
+          'The presence of yarn.lock ' +
+          'indicates that yarn should be used, but the presence of ' +
+          'package-lock.json indicates npm should be used.  Use the skip_files ' +
+          'section of app.yaml to ignore the appropriate file to indicate ' +
+          'which package manager to use.')
     });
   });
 });


### PR DESCRIPTION
Now `npm` will be used as the package manager if:
* Neither `yarn.lock` nor `package-lock.json` exist
* `package-lock.json` exists but `yarn.lock` does not exist

`yarn` will be used as if:
* `yarn.lock` exists but `package-lock.json` does not exist

An error will be thrown if:
* Both `yarn.lock` and `package-lock.json` exist

The appropriate filename can be added to the `skip_files`
section of `app.yaml` to address the case where both `yarn.lock`
and `package-lock.json` exist.