### PR TITLE
Replace "Container Engine" by "Kubernetes Engine".

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This repository contains the source for the Google-maintained Node.js [docker](https://docker.com) image.
 This image can be found at `launcher.gcr.io/google/nodejs` or `gcr.io/google-appengine/nodejs` and can be used as the base image
 for running applications on [Google App Engine Flexible](https://cloud.google.com/appengine),
-[Google Container Engine](https://cloud.google.com/container-engine), or any other Docker host.
+[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine), or any other Docker host.
 
 This image is based on Debian Jessie and includes [nodejs](https://nodejs.org) and [npm](https://npmjs.org) installed from [nodejs.org](http://nodejs.org/download/) and [yarn](https://yarnpkg.com) installed from [yarnpkg.com](https://yarnpkg.com).
 
@@ -19,7 +19,7 @@ gcloud beta app gen-config --custom
 ```
 You can then modify the `Dockerfile` and `.dockerignore` as needed for you application.
 
-## Container Engine and Other Docker Hosts
+## Kubernetes Engine and Other Docker Hosts
 
 For other docker hosts, you'll need to create a `Dockerfile` based on this image that copies your application code and installs dependencies. For example:
 
@@ -35,7 +35,7 @@ RUN npm --unsafe-perm install
 
 By default, the `CMD` is set to `npm start`. You can change this by specifying your own [`CMD` or `ENTRYPOINT`](http://docs.docker.com/engine/reference/builder/#cmd).
 
-For a full example on deploying an application to Google Container Engine, see [this tutorial](https://cloud.google.com/nodejs/tutorials/bookshelf-on-container-engine).
+For a full example on deploying an application to Google Kubernetes Engine, see [this tutorial](https://cloud.google.com/nodejs/tutorials/bookshelf-on-container-engine).
 
 ### Kubernetes Configuration
 


### PR DESCRIPTION
Also rename a link to https://cloud.google.com/container-engine/.