### PR TITLE
chore: use the `container-structure-test` image

### DIFF
--- a/builder/steps/gen-dockerfile/cloudbuild.yaml.in
+++ b/builder/steps/gen-dockerfile/cloudbuild.yaml.in
@@ -5,9 +5,9 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: ['build', '--tag=${IMAGE}', '--no-cache=true', '.']
   id: BUILD
-- name: gcr.io/gcp-runtimes/structure_test
-  args: ['--image', '${IMAGE}',
-  '-v', '--config', '/workspace/test_config.yaml']
+- name: gcr.io/gcp-runtimes/container-structure-test
+  args: ['test', '--image', '${IMAGE}',
+  '-v', 'DEBUG', '--config', '/workspace/test_config.yaml']
   id: STRUCTURE_TEST
 
 images: ['${IMAGE}']

--- a/runtime-image/cloudbuild.yaml.in
+++ b/runtime-image/cloudbuild.yaml.in
@@ -2,9 +2,9 @@ steps:
   - name: gcr.io/cloud-builders/docker
     args: ['build', '--tag=${IMAGE}', '--no-cache=true', '.']
     id: BUILD
-  - name: gcr.io/gcp-runtimes/structure_test
-    args: ['--image', '${IMAGE}',
-    '-v', '--config', '/workspace/test/test_config.yaml']
+  - name: gcr.io/gcp-runtimes/container-structure-test
+    args: ['test', '--image', '${IMAGE}',
+    '-v', 'DEBUG', '--config', '/workspace/test/test_config.yaml']
     id: STRUCTURE_TEST
 #  - name: gcr.io/gcp-runtimes/integration_test
 #    args: [


### PR DESCRIPTION
Previously the `gcr.io/gcp-runtimes/structure_test` image was
used.  However, that image is deprecated and was causing test
errors.