### PR TITLE
chore: remove Node 8 warning

### DIFF
--- a/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
+++ b/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
@@ -39,12 +39,6 @@ const NODE_VERSION_WARNING = 'WARNING:  Your package.json does not specify ' +
     'a supported Node.js version.  Please pin your application to a major ' +
     'version of the Node.js runtime.  To learn more, visit ' +
     'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime';
-const NODE_UPDATED_WARNING = 'WARNING: The default Node.js major version ' +
-    'is now Node 8 (instead of Node 6) because Node 8 has entered Long Term ' +
-    'Support.  Since you have not pinned your application to a major ' +
-    'version of the Node.js runtime, your application will automatically ' +
-    'use Node 8.  To learn how to pin to a version of the Node.js runtime ' +
-    'see https://cloud.google.com/appengine/docs/flexible/nodejs/runtime';
 
 const BUILD_SCRIPT_NAME = 'gcp-build';
 
@@ -225,7 +219,6 @@ export async function detectSetup(
 
   if (!nodeVersion) {
     warn(NODE_VERSION_WARNING);
-    warn(NODE_UPDATED_WARNING);
   }
 
   if (!gotScriptsStart && !(await fsview.exists('server.js'))) {

--- a/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
@@ -43,12 +43,6 @@ const NODE_VERSION_WARNING = 'WARNING:  Your package.json does not specify ' +
     'a supported Node.js version.  Please pin your application to a major ' +
     'version of the Node.js runtime.  To learn more, visit ' +
     'https://cloud.google.com/appengine/docs/flexible/nodejs/runtime';
-const NODE_UPDATED_WARNING = 'WARNING: The default Node.js major version ' +
-    'is now Node 8 (instead of Node 6) because Node 8 has entered Long Term ' +
-    'Support.  Since you have not pinned your application to a major ' +
-    'version of the Node.js runtime, your application will automatically ' +
-    'use Node 8.  To learn how to pin to a version of the Node.js runtime ' +
-    'see https://cloud.google.com/appengine/docs/flexible/nodejs/runtime';
 
 interface TestConfig {
   title: string;
@@ -181,7 +175,7 @@ describe('detectSetup', () => {
       ],
       expectedLogs: exactly(
           ['Checking for Node.js.', 'node.js checker: No package.json file.']),
-      expectedErrors: exactly([NODE_VERSION_WARNING, NODE_UPDATED_WARNING]),
+      expectedErrors: exactly([NODE_VERSION_WARNING]),
       expectedResult: undefined,
       expectedThrownErrMessage: new RegExp(
           'node.js checker: Neither "start" in the ' +
@@ -204,7 +198,7 @@ describe('detectSetup', () => {
           expectedLogs: exactly([
             'Checking for Node.js.', 'node.js checker: No package.json file.'
           ]),
-          expectedErrors: exactly([NODE_VERSION_WARNING, NODE_UPDATED_WARNING]),
+          expectedErrors: exactly([NODE_VERSION_WARNING]),
           expectedResult: {
             canInstallDeps: false,
             useYarn: false,
@@ -225,7 +219,7 @@ describe('detectSetup', () => {
             {path: 'package-lock.json', exists: false}
           ],
           expectedLogs: exactly(['Checking for Node.js.']),
-          expectedErrors: exactly([NODE_VERSION_WARNING, NODE_UPDATED_WARNING]),
+          expectedErrors: exactly([NODE_VERSION_WARNING]),
           expectedResult: {
             canInstallDeps: true,
             useYarn: false,
@@ -250,7 +244,7 @@ describe('detectSetup', () => {
             {path: 'package-lock.json', exists: false}
           ],
           expectedLogs: exactly(['Checking for Node.js.']),
-          expectedErrors: exactly([NODE_VERSION_WARNING, NODE_UPDATED_WARNING]),
+          expectedErrors: exactly([NODE_VERSION_WARNING]),
           expectedResult: {
             canInstallDeps: true,
             useYarn: false,
@@ -270,7 +264,7 @@ describe('detectSetup', () => {
             {path: 'package-lock.json', exists: false}
           ],
           expectedLogs: exactly(['Checking for Node.js.']),
-          expectedErrors: exactly([NODE_VERSION_WARNING, NODE_UPDATED_WARNING]),
+          expectedErrors: exactly([NODE_VERSION_WARNING]),
           expectedResult: {
             canInstallDeps: true,
             useYarn: true,
@@ -294,7 +288,7 @@ describe('detectSetup', () => {
             {path: 'package-lock.json', exists: false}
           ],
           expectedLogs: exactly(['Checking for Node.js.']),
-          expectedErrors: exactly([NODE_VERSION_WARNING, NODE_UPDATED_WARNING]),
+          expectedErrors: exactly([NODE_VERSION_WARNING]),
           expectedResult: {
             canInstallDeps: true,
             useYarn: false,
@@ -323,7 +317,7 @@ describe('detectSetup', () => {
             {path: 'package-lock.json', exists: false}
           ],
           expectedLogs: exactly(['Checking for Node.js.']),
-          expectedErrors: exactly([NODE_VERSION_WARNING, NODE_UPDATED_WARNING]),
+          expectedErrors: exactly([NODE_VERSION_WARNING]),
           expectedResult: {
             canInstallDeps: true,
             useYarn: false,
@@ -348,7 +342,7 @@ describe('detectSetup', () => {
             {path: 'package-lock.json', exists: false}
           ],
           expectedLogs: exactly(['Checking for Node.js.']),
-          expectedErrors: exactly([NODE_VERSION_WARNING, NODE_UPDATED_WARNING]),
+          expectedErrors: exactly([NODE_VERSION_WARNING]),
           expectedResult: {
             canInstallDeps: true,
             useYarn: true,
@@ -924,66 +918,6 @@ describe('detectSetup', () => {
         {path: 'package-lock.json', exists: false}
       ],
       expectedErrors: noneOf([NODE_VERSION_WARNING]),
-      expectedResult: {
-        canInstallDeps: true,
-        nodeVersion: 'something',
-        useYarn: false,
-        hasBuildCommand: false,
-        appYamlPath: DEFAULT_APP_YAML
-      }
-    });
-
-    performTest({
-      title: 'should warn of upcoming Node version update with package.json',
-      locations: [
-        {path: 'package.json', exists: true, contents: '{}'},
-        {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
-        {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
-        {path: 'yarn.lock', exists: false},
-        {path: 'package-lock.json', exists: false}
-      ],
-      expectedErrors: eachOf([NODE_UPDATED_WARNING]),
-      expectedResult: {
-        canInstallDeps: true,
-        useYarn: false,
-        hasBuildCommand: false,
-        appYamlPath: DEFAULT_APP_YAML
-      }
-    });
-
-    performTest({
-      title: 'should warn of upcoming Node version update without package.json',
-      locations: [
-        {path: 'package.json', exists: false},
-        {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
-        {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
-        {path: 'yarn.lock', exists: false},
-        {path: 'package-lock.json', exists: false}
-      ],
-      expectedErrors: eachOf([NODE_UPDATED_WARNING]),
-      expectedResult: {
-        canInstallDeps: false,
-        useYarn: false,
-        hasBuildCommand: false,
-        appYamlPath: DEFAULT_APP_YAML
-      }
-    });
-
-    performTest({
-      title: 'should not warn of upcoming Node version update if pinned ' +
-          'to a node version',
-      locations: [
-        {
-          path: 'package.json',
-          exists: true,
-          contents: JSON.stringify({engines: {node: 'something'}})
-        },
-        {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
-        {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
-        {path: 'yarn.lock', exists: false},
-        {path: 'package-lock.json', exists: false}
-      ],
-      expectedErrors: noneOf([NODE_UPDATED_WARNING]),
       expectedResult: {
         canInstallDeps: true,
         nodeVersion: 'something',


### PR DESCRIPTION
This is no longer necessary, as Node 8 has been the default for a fair
amount of time already.