### PR TITLE
Use kaniko for builds

### DIFF
--- a/builder/nodejs.yaml
+++ b/builder/nodejs.yaml
@@ -1,8 +1,5 @@
 steps:
-  - name: 'gcr.io/gcp-runtimes/nodejs/gen-dockerfile:latest'
-    args: ['--runtime-image', 'gcr.io/google-appengine/nodejs:latest']
-  - name: 'gcr.io/cloud_builders/docker:latest'
-    args: ['build', '-t', '$_OUTPUT_IMAGE', '.']
-
-images:
-  - '$_OUTPUT_IMAGE'
+- name: 'gcr.io/gcp-runtimes/nodejs/gen-dockerfile:latest'
+  args: ['--runtime-image', 'gcr.io/google-appengine/nodejs:latest']
+- name: 'gcr.io/kaniko-project/executor:v0.4.0'
+  args: ['--destination=$_OUTPUT_IMAGE']


### PR DESCRIPTION
kaniko builds container images from a Dockerfile, and enables future improvements to speed up builds by using the image registry as a layer cache (GoogleContainerTools/kaniko#300)