### PR TITLE
fix: Available versions sorting

### DIFF
--- a/runtime-image/contents/install_node
+++ b/runtime-image/contents/install_node
@@ -43,7 +43,7 @@ function getAvailableVersions(cb) {
         body
           .trim()
           .split('\n')
-          .sort((a, b) => {
+          .sort(function(a, b) {
             if (semver.gt(a, b)) {
               return -1;
             }

--- a/runtime-image/contents/install_node
+++ b/runtime-image/contents/install_node
@@ -38,7 +38,18 @@ function getAvailableVersions(cb) {
       if (err) {
         return cb(err);
       }
-      return cb(null, body.trim().split('\n').sort().reverse());
+      return cb(
+        null,
+        body
+          .trim()
+          .split('\n')
+          .sort((a, b) => {
+            if (semver.gt(a, b)) {
+              return -1;
+            }
+            return +1;
+          })
+      );
     }
   );
 }

--- a/runtime-image/test/definitions/verify-version-sort/Dockerfile
+++ b/runtime-image/test/definitions/verify-version-sort/Dockerfile
@@ -1,0 +1,7 @@
+FROM test/nodejs
+RUN install_node v9
+COPY . /app/
+RUN npm install --unsafe-perm || \
+  ((if [ -f npm-debug.log ]; then \
+      cat npm-debug.log; \
+    fi) && false)

--- a/runtime-image/test/definitions/verify-version-sort/package.json
+++ b/runtime-image/test/definitions/verify-version-sort/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "base-install-node",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  }
+}

--- a/runtime-image/test/definitions/verify-version-sort/run.sh
+++ b/runtime-image/test/definitions/verify-version-sort/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cat /opt/gcp/runtime/KEYS | gpg --dearmor > /tmp/keys
+gpg --keyring /tmp/keys --list-keys --keyid-format long

--- a/runtime-image/test/definitions/verify-version-sort/server.js
+++ b/runtime-image/test/definitions/verify-version-sort/server.js
@@ -1,0 +1,7 @@
+'use strict';
+var http = require('http');
+var child_process = require('child_process');
+var server = http.createServer(function(request, response) {
+  response.writeHead(200, {"Content-Type": "text/plain"});
+  response.end(process.version);
+}).listen(8080);

--- a/runtime-image/test/test.ts
+++ b/runtime-image/test/test.ts
@@ -152,6 +152,11 @@ const CONFIGURATIONS: TestConfig[] = [
     description: 'verify the set of keys in the keyring',
     tag: 'test/definitions/verify-gpg-keyring',
     expectedOutput: GPG_KEYS
+  },
+  {
+    description: 'verify list of available versions is properly sorted',
+    tag: 'test/definitions/verify-version-sort',
+    expectedOutput: 'v9.11.2'
   }
 ];
 


### PR DESCRIPTION
Hi 👋 

The sort in [getAvailableVersions](https://github.com/GoogleCloudPlatform/nodejs-docker/blob/b4c2ce0d4aff8e4863b53be847354fc13e582cd9/runtime-image/contents/install_node#L41) doesn't work when minor or patch versions are greater than 9.

Example:

If I run `install_node 9` today, it will install Node v9.9.0 and not the latest version which is 9.11.2. 

Versions are sorted like this:

<img width="91" alt="image" src="https://user-images.githubusercontent.com/8517072/49282589-d40e2e80-f48f-11e8-9875-3705a176ff9b.png">


To fix this issue we can use a semver based sort instead of the default string sort:
```javascript
versions.sort((a, b) => {
  if (semver.gt(a, b)) {
     return -1;
   }
   return +1;
})
```

Result:

<img width="99" alt="image" src="https://user-images.githubusercontent.com/8517072/49282539-b04ae880-f48f-11e8-8ac9-4944323572fb.png">

