### PR TITLE
Adding apt-get upgrade to make sure we get latest krb5 packages

### DIFF
--- a/runtime-image/Dockerfile
+++ b/runtime-image/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update -y && \
       libkrb5-dev \
       netbase \
       python && \
+    apt-get upgrade -y && \
     apt-get clean && \
     rm /var/lib/apt/lists/*_*
 

--- a/runtime-image/test/definitions/yarn-local/npm-shrinkwrap.json
+++ b/runtime-image/test/definitions/yarn-local/npm-shrinkwrap.json
@@ -910,9 +910,9 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "yarn": {
-      "version": "1.12.3",
-      "from": "yarn@1.12.3",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.12.3.tgz"
+      "version": "1.13.0",
+      "from": "yarn@1.13.0",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.13.0.tgz"
     }
   }
 }

--- a/runtime-image/test/test.ts
+++ b/runtime-image/test/test.ts
@@ -82,7 +82,7 @@ pub   4096R/23EFEFE93C4CFFFE 2017-01-23 [expires: 2033-01-19]
 uid                          Italo A. Casas <me@italoacasas.com>
 sub   4096R/D3C55C2AAEC2131D 2017-01-23 [expires: 2033-01-19]
 
-pub   4096R/50A3051F888C628D 2015-01-08 [expires: 2019-01-08]
+pub   4096R/50A3051F888C628D 2015-01-08 [expired: 2019-01-08]
 uid                          Julien Gilli <jgilli@fastmail.fm>
 sub   4096R/926EC77D21D4BD24 2015-01-08 [expires: 2019-01-08]
 

--- a/runtime-image/test/test.ts
+++ b/runtime-image/test/test.ts
@@ -84,7 +84,6 @@ sub   4096R/D3C55C2AAEC2131D 2017-01-23 [expires: 2033-01-19]
 
 pub   4096R/50A3051F888C628D 2015-01-08 [expired: 2019-01-08]
 uid                          Julien Gilli <jgilli@fastmail.fm>
-sub   4096R/926EC77D21D4BD24 2015-01-08 [expires: 2019-01-08]
 
 pub   1024D/7D33FF9D0246406D 2006-01-18 [expired: 2016-03-26]
 uid                          Timothy J Fontaine (Personal) <tjfontaine@gmail.com>
@@ -112,7 +111,7 @@ const CONFIGURATIONS: TestConfig[] = [
   {
     description: 'can install yarn locally',
     tag: 'test/definitions/yarn-local',
-    expectedOutput: '1.12.3\n'
+    expectedOutput: '1.13.0\n'
   },
   {
     description: 'can install yarn globally',


### PR DESCRIPTION
Addressing a CVE with an older version of krb5