### PR TITLE
If both yarn.lock and package-lock.json exist

### DIFF
--- a/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
+++ b/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
@@ -236,7 +236,7 @@ export async function detectSetup(
     npmVersion: escape(npmVersion),
     yarnVersion: escape(yarnVersion),
     nodeVersion: escape(nodeVersion),
-    useYarn: yarnLockExists && !(yarnLockExists && packageLockExists)
+    useYarn: yarnLockExists && !(yarnLockExists && packageLockExists),
     hasBuildCommand,
     appYamlPath
   };

--- a/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
+++ b/builder/steps/gen-dockerfile/contents/src/detect_setup.ts
@@ -168,9 +168,6 @@ export async function detectSetup(
       !isSkipped(YARN_LOCK) && await fsview.exists(YARN_LOCK);
   const packageLockExists: boolean =
       !isSkipped(PACKAGE_LOCK_JSON) && await fsview.exists(PACKAGE_LOCK_JSON);
-  if (yarnLockExists && packageLockExists) {
-    throw new Error(CANNOT_RESOLVE_PACKAGE_MANAGER);
-  }
 
   let canInstallDeps: boolean;
   let gotScriptsStart: boolean;
@@ -232,12 +229,14 @@ export async function detectSetup(
   // to properly verify it is of type `Setup`.  If its value is directly
   // passed to the `extend` function, the compiler cannot check
   // that the input is of type `Setup` since `extend` takes `Object`s.
+  //
+  // if both yarn lock and package lock exist, default to using NPM
   const setup: Setup = {
     canInstallDeps,
     npmVersion: escape(npmVersion),
     yarnVersion: escape(yarnVersion),
     nodeVersion: escape(nodeVersion),
-    useYarn: yarnLockExists,
+    useYarn: yarnLockExists && !(yarnLockExists && packageLockExists)
     hasBuildCommand,
     appYamlPath
   };

--- a/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
@@ -717,25 +717,6 @@ describe('detectSetup', () => {
       }
     });
 
-    performTest({
-      title: 'should throw an error if both yarn.lock and ' +
-          'package-lock.json exist and package.json does not exist',
-      locations: [
-        {path: 'package.json', exists: false},
-        {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
-        {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
-        {path: 'yarn.lock', exists: true},
-        {path: 'package-lock.json', exists: true}
-      ],
-      expectedResult: undefined,
-      expectedThrownErrMessage: new RegExp(
-          '^Cannot determine which package manager to use as both yarn.lock ' +
-          'and package-lock.json files were detected.  The presence of ' +
-          'yarn.lock indicates that yarn should be used, but the presence ' +
-          'of package-lock.json indicates npm should be used.  Use the ' +
-          'skip_files section of app.yaml to ignore the appropriate file ' +
-          'to indicate which package manager to use.$')
-    });
   });
 
   describe('should handle build commands', () => {

--- a/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
@@ -716,7 +716,6 @@ describe('detectSetup', () => {
         hasBuildCommand: false
       }
     });
-
   });
 
   describe('should handle build commands', () => {

--- a/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
+++ b/builder/steps/gen-dockerfile/contents/test/detect_setup_test.ts
@@ -719,25 +719,6 @@ describe('detectSetup', () => {
 
     performTest({
       title: 'should throw an error if both yarn.lock and ' +
-          'package-lock.json exist and package.json exists',
-      locations: [
-        {path: 'package.json', exists: true, contents: '{}'},
-        {path: 'server.js', exists: true, contents: SERVER_JS_CONTENTS},
-        {path: 'app.yaml', exists: true, contents: VALID_APP_YAML_CONTENTS},
-        {path: 'yarn.lock', exists: true},
-        {path: 'package-lock.json', exists: true}
-      ],
-      expectedResult: undefined,
-      expectedThrownErrMessage: new RegExp(
-          'The presence of yarn.lock ' +
-          'indicates that yarn should be used, but the presence of ' +
-          'package-lock.json indicates npm should be used.  Use the skip_files ' +
-          'section of app.yaml to ignore the appropriate file to indicate ' +
-          'which package manager to use.')
-    });
-
-    performTest({
-      title: 'should throw an error if both yarn.lock and ' +
           'package-lock.json exist and package.json does not exist',
       locations: [
         {path: 'package.json', exists: false},


### PR DESCRIPTION
If both yarn.lock and package-lock.json exist then we want to default to using npm.