### PR TITLE
Remove refs to gs://gae_node_packages

### DIFF
--- a/runtime-image/contents/bootstrap_node
+++ b/runtime-image/contents/bootstrap_node
@@ -29,7 +29,7 @@ function usage() {
   echo "                                 fails, the installation is aborted."
   echo "  --direct                       Download and install directly from"
   echo "                                 nodejs.org instead of from"
-  echo "                                 https://storage.googleapis.com/gae_node_packages"
+  echo "                                 https://storage.googleapis.com/gcp_node_packages"
   echo "  --help                         Prints this help message"
   echo ""
   echo "  version                        The version of Node.js to install."

--- a/runtime-image/contents/bootstrap_node
+++ b/runtime-image/contents/bootstrap_node
@@ -29,7 +29,7 @@ function usage() {
   echo "                                 fails, the installation is aborted."
   echo "  --direct                       Download and install directly from"
   echo "                                 nodejs.org instead of from"
-  echo "                                 https://storage.googleapis.com/gcp_node_packages"
+  echo "                                 https://storage.googleapis.com/gcp-node-packages"
   echo "  --help                         Prints this help message"
   echo ""
   echo "  version                        The version of Node.js to install."

--- a/runtime-image/contents/bootstrap_node
+++ b/runtime-image/contents/bootstrap_node
@@ -93,7 +93,7 @@ if [ "${direct}" == "true" ]; then
   # verify the Node.js binary
   checksum_file="SHASUMS256.txt.asc"
 else
-  base_url="https://storage.googleapis.com/gae_node_packages"
+  base_url="https://storage.googleapis.com/gcp-node-packages"
   checksum_file="${node_version}-SHASUMS256.txt.asc"
 fi
 

--- a/runtime-image/contents/install_node
+++ b/runtime-image/contents/install_node
@@ -33,7 +33,7 @@ function request(method, host, path, cb) {
 
 function getAvailableVersions(cb) {
   request(
-    'GET', 'storage.googleapis.com', '/gae_node_packages/node_versions',
+    'GET', 'storage.googleapis.com', '/gcp-node-packages/node_versions',
     function(err, body) {
       if (err) {
         return cb(err);
@@ -78,7 +78,7 @@ function verifyBinaryExists(version, cb) {
   request(
     'HEAD',
     'storage.googleapis.com',
-    '/gae_node_packages/node-' + version + '-linux-x64.tar.gz',
+    '/gcp-node-packages/node-' + version + '-linux-x64.tar.gz',
     function(err) {
       if (err) {
         return cb(new Error(
@@ -160,7 +160,7 @@ function printUsageAndExit() {
   console.log('                                 fails, the installation is aborted.');
   console.log('  --direct                       Download and install directly from');
   console.log('                                 nodejs.org instead of from');
-  console.log('                                 https://storage.googleapis.com/gae_node_packages');
+  console.log('                                 https://storage.googleapis.com/gcp-node-packages');
   console.log('  --help                         Prints this help message');
   console.log('');
   console.log('  version                        The version of Node.js to install.');


### PR DESCRIPTION
This points to a bucket located in the GCP project `gcp-runtimes`. The reason is that the old bucket isn't in `gcp-runtimes`, and it's easier to point to a mirrored bucket in `gcp-runtimes` (yes, it already exists) than it is to switch the project (requires a cross-project service account, and that's not feasible for security reasons)